### PR TITLE
[BB-1247] Fix bot directives

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -399,11 +399,11 @@ SPRINT_STATUS_EPIC_IN_PROGRESS = {
     SPRINT_STATUS_IN_DEVELOPMENT,
 }
 # String for overriding how much time will be needed for an epic management per sprint.
-SPRINT_EPIC_DIRECTIVE = fr"[~${JIRA_BOT_USERNAME}]: plan (\d+) hours per sprint for epic management"
+SPRINT_EPIC_DIRECTIVE = fr"\[~{JIRA_BOT_USERNAME}\]: plan (\d+) hours per sprint for epic management"
 # String for overriding how much time will be needed for a recurring task per sprint.
-SPRINT_RECURRING_DIRECTIVE = fr"[~${JIRA_BOT_USERNAME}]: plan (\d+) hours per sprint for this task"
+SPRINT_RECURRING_DIRECTIVE = fr"\[~{JIRA_BOT_USERNAME}\]: plan (\d+) hours per sprint for this task"
 # String for overriding how much time will be needed for the task's review.
-SPRINT_REVIEW_DIRECTIVE = fr"[~${JIRA_BOT_USERNAME}]: plan (\d+) hours for reviewing this task"
+SPRINT_REVIEW_DIRECTIVE = fr"\[~{JIRA_BOT_USERNAME}\]: plan (\d+) hours for reviewing this task"
 # Regex for extracting sprint number from the name of the sprint.
 SPRINT_NUMBER_REGEX = env.str("SPRINT_NUMBER_REGEX", r"Sprint (\d+)")
 # Regex for extracting sprint staring date from the name of the sprint.


### PR DESCRIPTION
This fixes defining custom assignee/reviewer time with bot directives.

## Testing instructions:
1. Set `.env` according to the ticket description.
1. Start the backend with `docker-compose -f local.yml up --build`.
1. Create superuser with `docker-compose -f local.yml run --rm django python manage.py createsuperuser` (the button on frontend should be visible for `staff` users only).
1. Add email to your superuser account under `http://localhost:8000/admin/account/emailaddress/`.
1. Navigate to `frontend` and run `npm i && npm start`.
1. Log into the frontend.
1. Compare the results on `master` and this branch. Please use the linked forum post as a reference for checking the values.