### PR TITLE
[BB-1497] Move archived issues out of the sprint before closing it

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -326,6 +326,8 @@ JIRA_USERNAME = env.str("JIRA_USERNAME")
 JIRA_PASSWORD = env.str("JIRA_PASSWORD")
 # THe prefix used for distinguishing sprint boards from other ones.
 JIRA_SPRINT_BOARD_PREFIX = env.str("SPRINT_BOARD_PREFIX", "Sprint - ")
+# THe prefix used for distinguishing standard sprints from special ones (e.g. Stretch Goals).
+JIRA_SPRINT_PREFIX = env.str("SPRINT_BOARD_PREFIX", "Sprint ")
 # Username of a helper Jira bot used for indicating custom review time requirements.
 JIRA_BOT_USERNAME = env.str("JIRA_BOT_USERNAME", "crafty")
 JIRA_REQUIRED_FIELDS = (
@@ -380,6 +382,7 @@ SPRINT_STATUS_ACCEPTED = "Accepted"
 SPRINT_STATUS_IN_DEVELOPMENT = "In development"
 SPRINT_STATUS_DEPLOYED_AND_DELIVERED = "Deployed & Delivered"
 SPRINT_STATUS_DONE = "Done"
+SPRINT_STATUS_ARCHIVED = "Archived"
 # Which tickets statuses will be counted as a spillover.
 SPRINT_STATUS_SPILLOVER = {
     SPRINT_STATUS_BACKLOG,

--- a/frontend/src/components/CompleteSprintsButton.js
+++ b/frontend/src/components/CompleteSprintsButton.js
@@ -6,6 +6,10 @@ const PATH_COMPLETE_SPRINTS = `${process.env.REACT_APP_API_BASE}/dashboard/compl
 
 class CompleteSprintsButton extends Component {
     completeSprints = () => {
+        if (window.confirm("Are you sure you want to end the current sprint?") !== true) {
+            return;
+        }
+
         this.btn.setAttribute("disabled", "disabled");
         let token = this.props.auth.token;
         let headers = {

--- a/sprints/dashboard/libs/google.py
+++ b/sprints/dashboard/libs/google.py
@@ -52,7 +52,8 @@ def get_vacations(from_: str, to: str) -> List[Dict[str, Union[str, Dict[str, st
 
             for event in events['items']:
                 user_search = re.match(GOOGLE_CALENDAR_VACATION_REGEX, event['summary'], re.IGNORECASE)
-                if user_search:
+                # Only `All day` events are taken into account.
+                if user_search and {'start', 'end'} <= event.keys():
                     user = user_search.group(1)
                     del event['summary']
                     event['user'] = user

--- a/sprints/dashboard/models.py
+++ b/sprints/dashboard/models.py
@@ -44,6 +44,7 @@ from sprints.dashboard.utils import (
     extract_sprint_id_from_str,
     find_next_sprint,
     get_cell_members,
+    get_sprints,
     prepare_jql_query,
 )
 
@@ -207,18 +208,18 @@ class Dashboard:
 
     def get_sprints(self) -> None:
         """Retrieves current and future sprint for the board."""
-        sprints: List[Sprint] = self.jira_connection.sprints(self.board_id, state='active, future')
+        sprints: List[Sprint] = get_sprints(self.jira_connection, self.board_id)
 
         for sprint in sprints:
-            if sprint.name.startswith('Sprint') and sprint.state == 'active':
+            if sprint.state == 'active':
                 self.sprint = sprint
                 break
 
-        self.future_sprint = find_next_sprint(sprints, self.sprint)
+        self.future_sprint = find_next_sprint(sprints, self.sprint, self.jira_connection)
         future_sprint_start_search = re.search(SPRINT_DATE_REGEX, self.future_sprint.name)
         self.future_sprint_start = future_sprint_start_search.group(1) if future_sprint_start_search else None
 
-        next_future_sprint = find_next_sprint(sprints, self.future_sprint)
+        next_future_sprint = find_next_sprint(sprints, self.future_sprint, self.jira_connection)
         next_future_sprint_start_search = re.search(SPRINT_DATE_REGEX, next_future_sprint.name)
         next_future_sprint_start = next_future_sprint_start_search.group(1) if next_future_sprint_start_search else None
         end_date = datetime.strptime(next_future_sprint_start, '%Y-%m-%d') - timedelta(days=1)

--- a/sprints/dashboard/tasks.py
+++ b/sprints/dashboard/tasks.py
@@ -18,6 +18,7 @@ from sprints.dashboard.utils import (
     get_spillover_issues,
     prepare_jql_query_active_sprint_tickets,
     prepare_spillover_rows,
+    get_sprints,
 )
 
 
@@ -42,19 +43,31 @@ def complete_sprints():
     upload_spillovers_task()
     with connect_to_jira() as conn:
         cell = get_cells(conn)[0]  # The sprint is shared between cells, so we need only one ID.
-        sprints: List[Sprint] = conn.sprints(cell.board_id, state='active, future')
-        active_sprint = None
+        sprints: List[Sprint] = get_sprints(conn, cell.board_id)
         for sprint in sprints:
-            if sprint.name.startswith('Sprint') and sprint.state == 'active':
+            if sprint.state == 'active':
                 active_sprint = sprint
                 break
-        if active_sprint:
-            future_sprint = find_next_sprint(sprints, active_sprint)
-        else:
-            for sprint in sprints:
-                if sprint.name.startswith('Sprint'):
-                    future_sprint = sprint
-                    break
+
+        future_sprint = find_next_sprint(sprints, active_sprint, conn)
+
+        archived_issues: List[Issue] = conn.search_issues(
+            **prepare_jql_query_active_sprint_tickets(
+                list(),  # We don't need any fields here. The `key` attribute will be sufficient.
+                {settings.SPRINT_STATUS_ARCHIVED},
+            ),
+            maxResults=0,
+        )
+        archived_issue_keys = [issue.key for issue in archived_issues]
+
+        # Remove archived tickets from the active sprint. Leaving them might interrupt closing the sprint properly.
+        # It is not mentioned in Python lib docs, but the limit for the next query is 50 issues. Source:
+        # https://developer.atlassian.com/cloud/jira/software/rest/#api-rest-agile-1-0-backlog-issue-post
+        batch_size = 50
+        if not settings.DEBUG:  # We really don't want to trigger this in the dev environment.
+            for i in range(0, len(archived_issue_keys), batch_size):
+                batch = archived_issue_keys[i:i + batch_size]
+                conn.move_to_backlog(batch)
 
         issues: List[Issue] = conn.search_issues(
             **prepare_jql_query_active_sprint_tickets(
@@ -66,13 +79,14 @@ def complete_sprints():
         issue_keys = [issue.key for issue in issues]
 
         # Close active sprint and open future one.
-        conn.update_sprint(active_sprint.id, state='closed')
-        conn.update_sprint(future_sprint.id, state='active')
+        if not settings.DEBUG:  # We really don't want to trigger this in the dev environment.
+            conn.update_sprint(active_sprint.id, state='closed')
+            conn.update_sprint(future_sprint.id, state='active')
 
         # Move issues to the active sprint from the closed one.
         # It is not mentioned in Python lib docs, but the limit for the next query is 50 issues. Source:
         # https://developer.atlassian.com/cloud/jira/software/rest/#api-rest-agile-1-0-sprint-sprintId-issue-post
-        batch_size = 50
-        for i in range(0, len(issue_keys), batch_size):
-            batch = issue_keys[i:i + batch_size]
-            conn.add_issues_to_sprint(future_sprint.id, batch)
+        if not settings.DEBUG:  # We really don't want to trigger this in the dev environment.
+            for i in range(0, len(issue_keys), batch_size):
+                batch = issue_keys[i:i + batch_size]
+                conn.add_issues_to_sprint(future_sprint.id, batch)

--- a/sprints/dashboard/tests/test_utils.py
+++ b/sprints/dashboard/tests/test_utils.py
@@ -93,7 +93,7 @@ def test_find_next_sprint():
         MockItem(name='Sprint 124', state='future'),
     ]
     # noinspection PyTypeChecker
-    assert find_next_sprint(sprints, sprints[1]) == sprints[2]
+    assert find_next_sprint(sprints, sprints[1], MockJiraConnection()) == sprints[2]
 
 
 def test_prepare_jql_query():

--- a/sprints/dashboard/utils.py
+++ b/sprints/dashboard/utils.py
@@ -206,7 +206,7 @@ def prepare_spillover_rows(issues: List[Issue], issue_fields: Dict[str, str]) ->
                     pass
             if field == 'Sprint':
                 cell_value = map(extract_sprint_name_from_str, cell_value)
-                cell_value = '\n'.join(cell_value)
+                cell_value = tuple(cell_value)[-1]  # We need only the last sprint (when the spillover happened).
 
             row.append(str(cell_value))
 

--- a/sprints/dashboard/utils.py
+++ b/sprints/dashboard/utils.py
@@ -60,21 +60,45 @@ def get_cell_members(quickfilters: List[QuickFilter]) -> List[str]:
     return members
 
 
-def find_next_sprint(sprints: List[Sprint], previous_sprint: Sprint) -> Sprint:
-    """Find the consecutive sprint by its number."""
+def get_sprints(conn: CustomJira, board_id: int) -> List[Sprint]:
+    """Return the filtered list of the active and future sprints for the chosen board."""
+    sprints = conn.sprints(board_id, state='active, future')
+    return [sprint for sprint in sprints if sprint.name.startswith(settings.JIRA_SPRINT_PREFIX)]
+
+
+def find_next_sprint(sprints: List[Sprint], previous_sprint: Sprint, conn: CustomJira) -> Sprint:
+    """
+    Find the consecutive sprint by its number.
+    As the sprints are synchronized and Jira shows only the ones with issues, this function tries to get another cell's
+    sprints if the next one was not found in the current board.
+    """
     previous_sprint_number_search = re.search(settings.SPRINT_NUMBER_REGEX, previous_sprint.name)
     if previous_sprint_number_search:
         previous_sprint_number = int(previous_sprint_number_search.group(1))
     else:
         raise AttributeError("Invalid `previous_sprint`.")
 
+    next_sprint = _find_next_sprint(sprints, previous_sprint_number)
+
+    if not next_sprint:
+        cells = get_cells(conn)
+        for cell in cells:
+            cell_sprints = get_sprints(conn, cell.board_id)
+            next_sprint = _find_next_sprint(cell_sprints, previous_sprint_number)
+            if next_sprint:
+                break
+
+    return next_sprint
+
+
+def _find_next_sprint(sprints: List[Sprint], previous_sprint_number: int) -> Sprint:
+    """Find the consecutive sprint by its number."""
     for sprint in sprints:
-        if sprint.name.startswith('Sprint') and sprint.state == 'future':
-            sprint_number_search = re.search(settings.SPRINT_NUMBER_REGEX, sprint.name)
-            if sprint_number_search:
-                sprint_number = int(sprint_number_search.group(1))
-                if previous_sprint_number + 1 == sprint_number:
-                    return sprint
+        sprint_number_search = re.search(settings.SPRINT_NUMBER_REGEX, sprint.name)
+        if sprint_number_search:
+            sprint_number = int(sprint_number_search.group(1))
+            if previous_sprint_number + 1 == sprint_number:
+                return sprint
 
 
 def prepare_jql_query(current_sprint: int, future_sprint: int, fields: List[str]) -> Dict[str, Union[str, List[str]]]:


### PR DESCRIPTION
This adds removing archived tickets from the active sprint. Leaving them might interrupt closing the sprint properly.
Minor fixes included here:
- adds confirmation after clicking the `Complete Sprints` button,
- disables running the code related to ending the sprint via the dev environment,
- ignores calendar events with specific hours (it was failing, because they don't have `start` and `end`),
- reduces the number of sprints uploaded to the spillover report to the last one (the sprint, in which the issue spilled over),
- improves sprint detection by introducing the fallback to another cell if the future sprint was not found in the current one - this happens if there are no issues scheduled for the sprint in the specific cell.