### PR TITLE
[BB-1603] Hotfix for sprints naming

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -330,8 +330,6 @@ JIRA_USERNAME = env.str("JIRA_USERNAME")
 JIRA_PASSWORD = env.str("JIRA_PASSWORD")
 # THe prefix used for distinguishing sprint boards from other ones.
 JIRA_SPRINT_BOARD_PREFIX = env.str("SPRINT_BOARD_PREFIX", "Sprint - ")
-# THe prefix used for distinguishing standard sprints from special ones (e.g. Stretch Goals).
-JIRA_SPRINT_PREFIX = env.str("SPRINT_BOARD_PREFIX", "Sprint ")
 # Username of a helper Jira bot used for indicating custom review time requirements.
 JIRA_BOT_USERNAME = env.str("JIRA_BOT_USERNAME", "crafty")
 JIRA_REQUIRED_FIELDS = (
@@ -412,7 +410,10 @@ SPRINT_RECURRING_DIRECTIVE = fr"\[~{JIRA_BOT_USERNAME}\]: plan (\d+) hours per s
 # String for overriding how much time will be needed for the task's review.
 SPRINT_REVIEW_DIRECTIVE = fr"\[~{JIRA_BOT_USERNAME}\]: plan (\d+) hours for reviewing this task"
 # Regex for extracting sprint number from the name of the sprint.
-SPRINT_NUMBER_REGEX = env.str("SPRINT_NUMBER_REGEX", r"Sprint (\d+)")
+# It is also used for distinguishing standard sprints from special ones (e.g. Stretch Goals).
+# TODO: Uncomment this after ending the current sprint.
+# SPRINT_NUMBER_REGEX = env.str("SPRINT_NUMBER_REGEX", r"\w+\.(\d+)")
+SPRINT_NUMBER_REGEX = env.str("SPRINT_NUMBER_REGEX", r"\w+.*?(\d+)")
 # Regex for extracting sprint staring date from the name of the sprint.
 SPRINT_DATE_REGEX = env.str("SPRINT_DATE_REGEX", r"\((.*)\)")
 # Number of days that a sprint lasts

--- a/sprints/dashboard/utils.py
+++ b/sprints/dashboard/utils.py
@@ -63,7 +63,9 @@ def get_cell_members(quickfilters: List[QuickFilter]) -> List[str]:
 def get_sprints(conn: CustomJira, board_id: int) -> List[Sprint]:
     """Return the filtered list of the active and future sprints for the chosen board."""
     sprints = conn.sprints(board_id, state='active, future')
-    return [sprint for sprint in sprints if sprint.name.startswith(settings.JIRA_SPRINT_PREFIX)]
+    # TODO: Uncomment this after ending the current sprint.
+    # return [sprint for sprint in sprints if re.search(settings.SPRINT_NUMBER_REGEX, sprint.name)]
+    return sprints
 
 
 def find_next_sprint(sprints: List[Sprint], previous_sprint: Sprint, conn: CustomJira) -> Sprint:


### PR DESCRIPTION
This is a hotfix for changed sprints naming convention. There is a typo in retrieving env variables, so we cannot just change it this way.
It doesn't handle cross-cell tickets, it just fixes the dashboard. The cross-cell tickets will be handled properly in #14.