### PR TITLE
[BB-1550] Retrieve the spillover reason from the comment

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -354,6 +354,7 @@ SPILLOVER_REQUIRED_FIELDS = (
     "Story Points",
     "Original Estimate",
     "Remaining Estimate",
+    "Comment",
 )
 # Issue fields that contain time in seconds.
 JIRA_TIME_FIELDS = {
@@ -409,6 +410,8 @@ SPRINT_EPIC_DIRECTIVE = fr"\[~{JIRA_BOT_USERNAME}\]: plan (\d+) hours per sprint
 SPRINT_RECURRING_DIRECTIVE = fr"\[~{JIRA_BOT_USERNAME}\]: plan (\d+) hours per sprint for this task"
 # String for overriding how much time will be needed for the task's review.
 SPRINT_REVIEW_DIRECTIVE = fr"\[~{JIRA_BOT_USERNAME}\]: plan (\d+) hours for reviewing this task"
+# Regexp for retrieving spillover reason from the issue's comment.
+SPILLOVER_REASON_DIRECTIVE = fr"\[~{JIRA_BOT_USERNAME}\]: <spillover>(.*)<\/spillover>"
 # Regex for extracting sprint number from the name of the sprint.
 # It is also used for distinguishing standard sprints from special ones (e.g. Stretch Goals).
 SPRINT_NUMBER_REGEX = env.str("SPRINT_NUMBER_REGEX", r"\w+.*?(\d+)")
@@ -437,3 +440,9 @@ GOOGLE_API_CREDENTIALS = {
 #          both of them will need to provide the full name in the calendar.
 GOOGLE_CALENDAR_VACATION_REGEX = env.str("GOOGLE_CALENDAR_VACATION_REGEX", r"(\w+) off")
 GOOGLE_SPILLOVER_SPREADSHEET = env.str("GOOGLE_SPILLOVER_SPREADSHEET")
+GOOGLE_SPILLOVER_SPREADSHEET_URL = f"https://docs.google.com/spreadsheets/d/{GOOGLE_SPILLOVER_SPREADSHEET}"
+# Message to put in the comment as a reminder to the user who forgot to post the spillover reason.
+SPILLOVER_REMINDER_MESSAGE = fr"please fill the spillover reason in the " \
+                             fr"[Spillover spreadsheet|{GOOGLE_SPILLOVER_SPREADSHEET_URL}] " \
+                             fr"and the next time add the spillover reason as a Jira comment " \
+                             fr"matching the following regexp: {{code:python}} {SPILLOVER_REASON_DIRECTIVE}{{code}}"

--- a/sprints/dashboard/libs/google.py
+++ b/sprints/dashboard/libs/google.py
@@ -7,14 +7,9 @@ from typing import (
     Union,
 )
 
+from django.conf import settings
 from google.oauth2 import service_account
 from googleapiclient import discovery
-
-from config.settings.base import (
-    GOOGLE_API_CREDENTIALS,
-    GOOGLE_CALENDAR_VACATION_REGEX,
-    GOOGLE_SPILLOVER_SPREADSHEET,
-)
 
 
 @contextmanager
@@ -24,7 +19,7 @@ def connect_to_google(service: str) -> Iterator[discovery.Resource]:
         'https://www.googleapis.com/auth/calendar',
         'https://www.googleapis.com/auth/spreadsheets',
     ]
-    credentials = service_account.Credentials.from_service_account_info(GOOGLE_API_CREDENTIALS, scopes=scopes)
+    credentials = service_account.Credentials.from_service_account_info(settings.GOOGLE_API_CREDENTIALS, scopes=scopes)
     api_version = {
         'calendar': 'v3',
         'sheets': 'v4',
@@ -51,7 +46,7 @@ def get_vacations(from_: str, to: str) -> List[Dict[str, Union[str, Dict[str, st
             ).execute()
 
             for event in events['items']:
-                user_search = re.match(GOOGLE_CALENDAR_VACATION_REGEX, event['summary'], re.IGNORECASE)
+                user_search = re.match(settings.GOOGLE_CALENDAR_VACATION_REGEX, event['summary'], re.IGNORECASE)
                 # Only `All day` events are taken into account.
                 if user_search and {'start', 'end'} <= event.keys():
                     user = user_search.group(1)
@@ -69,7 +64,7 @@ def upload_spillovers(spillovers: List[List[str]]) -> None:
         sheet = conn.spreadsheets()
         body = {'values': spillovers}
         sheet.values().append(
-            spreadsheetId=GOOGLE_SPILLOVER_SPREADSHEET,
+            spreadsheetId=settings.GOOGLE_SPILLOVER_SPREADSHEET,
             range='Spillovers',
             body=body,
             valueInputOption='USER_ENTERED',

--- a/sprints/dashboard/libs/google.py
+++ b/sprints/dashboard/libs/google.py
@@ -76,7 +76,7 @@ def get_commitments_spreadsheet(cell_name: str) -> List[List[str]]:
     with connect_to_google('sheets') as conn:
         sheet = conn.spreadsheets()
         return sheet.values().get(
-            spreadsheetId=GOOGLE_SPILLOVER_SPREADSHEET,
+            spreadsheetId=settings.GOOGLE_SPILLOVER_SPREADSHEET,
             range=f"'{cell_name} Commitments'!A3:ZZZ999",
             majorDimension='COLUMNS',
         ).execute()['values']
@@ -91,7 +91,7 @@ def upload_commitments(users: List[str], commitments: List[str], range_: str) ->
             'majorDimension': 'COLUMNS',
         }
         sheet.values().append(
-            spreadsheetId=GOOGLE_SPILLOVER_SPREADSHEET,
+            spreadsheetId=settings.GOOGLE_SPILLOVER_SPREADSHEET,
             range=range_.split('!')[0],
             body=users_body,
             valueInputOption='USER_ENTERED',
@@ -102,7 +102,7 @@ def upload_commitments(users: List[str], commitments: List[str], range_: str) ->
             'majorDimension': 'COLUMNS'
         }
         sheet.values().append(
-            spreadsheetId=GOOGLE_SPILLOVER_SPREADSHEET,
+            spreadsheetId=settings.GOOGLE_SPILLOVER_SPREADSHEET,
             range=range_,
             body=body,
             valueInputOption='USER_ENTERED',

--- a/sprints/dashboard/libs/jira.py
+++ b/sprints/dashboard/libs/jira.py
@@ -3,17 +3,12 @@ from typing import (
     Iterator,
 )
 
+from django.conf import settings
 from jira import JIRA
 from jira.client import ResultList
 from jira.resources import (
     GreenHopperResource,
     Resource,
-)
-
-from config.settings.base import (
-    JIRA_PASSWORD,
-    JIRA_SERVER,
-    JIRA_USERNAME,
 )
 
 
@@ -58,8 +53,8 @@ class CustomJira(JIRA):
 def connect_to_jira() -> Iterator[CustomJira]:
     """Context manager for establishing connection with Jira server."""
     conn = CustomJira(
-        server=JIRA_SERVER,
-        basic_auth=(JIRA_USERNAME, JIRA_PASSWORD),
+        server=settings.JIRA_SERVER,
+        basic_auth=(settings.JIRA_USERNAME, settings.JIRA_PASSWORD),
         options={'agile_rest_path': GreenHopperResource.AGILE_BASE_REST_PATH}
     )
     yield conn

--- a/sprints/dashboard/tasks.py
+++ b/sprints/dashboard/tasks.py
@@ -34,6 +34,7 @@ from sprints.dashboard.utils import (
     prepare_commitment_spreadsheet,
     prepare_jql_query_active_sprint_tickets,
     prepare_spillover_rows,
+    get_all_sprints,
 )
 
 
@@ -43,8 +44,10 @@ def upload_spillovers_task() -> None:
     with connect_to_jira() as conn:
         issue_fields = get_issue_fields(conn, SPILLOVER_REQUIRED_FIELDS)
         issues = get_spillover_issues(conn, issue_fields)
+        active_sprints = get_all_sprints(conn)['active']
 
-    rows = prepare_spillover_rows(issues, issue_fields)
+    active_sprints_dict = {int(sprint.id): sprint for sprint in active_sprints}
+    rows = prepare_spillover_rows(issues, issue_fields, active_sprints_dict)
     upload_spillovers(rows)
 
 

--- a/sprints/dashboard/tasks.py
+++ b/sprints/dashboard/tasks.py
@@ -15,7 +15,6 @@ from jira.resources import (
 )
 
 from config import celery_app
-from config.settings.base import SPILLOVER_REQUIRED_FIELDS
 from sprints.dashboard.libs.google import (
     get_commitments_spreadsheet,
     upload_commitments,
@@ -42,7 +41,7 @@ from sprints.dashboard.utils import (
 def upload_spillovers_task() -> None:
     """A task for documenting spillovers in the Google Spreadsheet."""
     with connect_to_jira() as conn:
-        issue_fields = get_issue_fields(conn, SPILLOVER_REQUIRED_FIELDS)
+        issue_fields = get_issue_fields(conn, settings.SPILLOVER_REQUIRED_FIELDS)
         issues = get_spillover_issues(conn, issue_fields)
         active_sprints = get_all_sprints(conn)['active']
 

--- a/sprints/dashboard/tests/test_utils.py
+++ b/sprints/dashboard/tests/test_utils.py
@@ -235,11 +235,14 @@ def test_prepare_jql_query_active_sprint_tickets_for_project():
     assert result == expected_result
 
 
-def test_extract_sprint_name_from_str():
-    sprint_str = 'com.atlassian.greenhopper.service.sprint.Sprint@614e3007[id=245,rapidViewId=26,state=CLOSED,' \
-                 'name=Sprint 197 (2019-06-18),startDate=2019-06-17T17:21:26.945Z,' \
-                 'endDate=2019-07-01T17:21:00.000Z,completeDate=2019-07-01T17:46:48.977Z,sequence=243,goal=] '
-    assert extract_sprint_name_from_str(sprint_str) == 'Sprint 197 (2019-06-18)'
+@pytest.mark.parametrize(
+    "test_input, expected", [
+        ('name=Sprint 197 (2019-06-18),startDate=2019-06-17T17:21:26.945Z', 'Sprint 197 (2019-06-18)'),
+        ('name=TS.197 (2019-06-18),startDate=2019-06-17T17:21:26.945Z', 'TS.197 (2019-06-18)'),
+    ],
+)
+def test_extract_sprint_name_from_str(test_input, expected):
+    assert extract_sprint_name_from_str(test_input) == expected
 
 
 def test_get_issue_fields():
@@ -248,6 +251,7 @@ def test_get_issue_fields():
         required_fields[0]: 'example_id1',
         required_fields[1]: 'example_id2',
     }
+    # noinspection PyTypeChecker
     assert get_issue_fields(MockJiraConnection(), required_fields) == expected_result
 
 
@@ -271,4 +275,5 @@ def test_prepare_spillover_rows():
         ['=HYPERLINK("https://example.com/browse/TEST-1","TEST-1")', '1', '2.0'],
         ['=HYPERLINK("https://example.com/browse/TEST-2","TEST-2")', '3', '2.74'],
     ]
-    assert prepare_spillover_rows(test_issues, issue_fields) == expected_result
+    # noinspection PyTypeChecker
+    assert prepare_spillover_rows(test_issues, issue_fields, {}) == expected_result

--- a/sprints/dashboard/utils.py
+++ b/sprints/dashboard/utils.py
@@ -225,7 +225,7 @@ def extract_sprint_id_from_str(sprint_str: str) -> int:
 
 def extract_sprint_name_from_str(sprint_str: str) -> str:
     """We're using custom field for `Sprint`, so the `sprint` field in the result is `str`."""
-    pattern = r'name=(.*?) '
+    pattern = r'name=(.*?\))'
     search = re.search(pattern, sprint_str)
     if search:
         return search.group(1)


### PR DESCRIPTION
This adds the ability to retrieve spillover reasons from the comments. The comment with the spillover reason should match the following regexp:
```python
fr"\[~{JIRA_BOT_USERNAME}\]: <spillover>(.*)<\/spillover>"
```

## Testing instructions:
1. Set `.env` file.
1. Checkout **`agrendalath/bb-1550-testing-branch`** (it includes dev condition for this ticket, which will allow testing this).
1. Start the backend with `docker-compose -f local.yml up --build`.
1. Create superuser with `docker-compose -f local.yml run --rm django python manage.py createsuperuser` (the button on frontend will be visible for `staff` users only).
1. Add email to your superuser account under `http://localhost:8000/admin/account/emailaddress/`.
1. Navigate to `frontend` and run `npm i && npm start`.
1. Log into the frontend.
1. Click the red `Complete Sprints` button and confirm it.
1. Check the new comment posted on the ticket (this is the debug one, it won't appear on the tickets, which have the spillover reason provided).
1. Check the spillover spreadsheet (the link is in the newly added comment) and confirm that the `BB-1550` ticket has the spillover reason filled properly.