### PR TITLE
[BB-1548] Export sprint commitments at the end of the sprint

### DIFF
--- a/sprints/dashboard/libs/google.py
+++ b/sprints/dashboard/libs/google.py
@@ -74,3 +74,41 @@ def upload_spillovers(spillovers: List[List[str]]) -> None:
             body=body,
             valueInputOption='USER_ENTERED',
         ).execute()
+
+
+def get_commitments_spreadsheet(cell_name: str) -> List[List[str]]:
+    """Retrieve the current commitment spreadsheet."""
+    with connect_to_google('sheets') as conn:
+        sheet = conn.spreadsheets()
+        return sheet.values().get(
+            spreadsheetId=GOOGLE_SPILLOVER_SPREADSHEET,
+            range=f"'{cell_name} Commitments'!A3:ZZZ999",
+            majorDimension='COLUMNS',
+        ).execute()['values']
+
+
+def upload_commitments(users: List[str], commitments: List[str], range_: str) -> None:
+    """Upload new members and commitments to the spreadsheet."""
+    with connect_to_google('sheets') as conn:
+        sheet = conn.spreadsheets()
+        users_body = {
+            'values': [users],
+            'majorDimension': 'COLUMNS',
+        }
+        sheet.values().append(
+            spreadsheetId=GOOGLE_SPILLOVER_SPREADSHEET,
+            range=range_.split('!')[0],
+            body=users_body,
+            valueInputOption='USER_ENTERED',
+        ).execute()
+
+        body = {
+            'values': [commitments],
+            'majorDimension': 'COLUMNS'
+        }
+        sheet.values().append(
+            spreadsheetId=GOOGLE_SPILLOVER_SPREADSHEET,
+            range=range_,
+            body=body,
+            valueInputOption='USER_ENTERED',
+        ).execute()

--- a/sprints/dashboard/utils.py
+++ b/sprints/dashboard/utils.py
@@ -292,7 +292,7 @@ def prepare_commitment_spreadsheet(dashboard, spreadsheet: List[List[str]]) -> T
     for user in spreadsheet[0][1:]:
         try:
             column.append(str(round(int(commitments.pop(user, '-')) / SECONDS_IN_HOUR)))
-        except TypeError:
+        except (TypeError, ValueError):
             column.append('-')
 
     # Process the users that don't exist in the spreadsheet yet.

--- a/sprints/dashboard/utils.py
+++ b/sprints/dashboard/utils.py
@@ -1,4 +1,5 @@
 import re
+import string
 from datetime import (
     datetime,
     timedelta,
@@ -9,6 +10,7 @@ from typing import (
     Iterable,
     List,
     Union,
+    Tuple,
 )
 
 from django.conf import settings
@@ -273,3 +275,40 @@ def prepare_spillover_rows(issues: List[Issue], issue_fields: Dict[str, str]) ->
 
         rows.append(row)
     return rows
+
+
+def prepare_commitment_spreadsheet(dashboard, spreadsheet: List[List[str]]) -> Tuple[List[str], List[str]]:
+    """Prepare list of new members (ones that are not present in the spreadsheet) and commitments for all members."""
+    sprint_number = int(spreadsheet[-1][0]) + 1
+    users: List[str] = []
+    column: List[str] = [str(sprint_number)]
+    commitments: Dict[str, int] = {
+        row.user.displayName: row.remaining_time
+        for row in dashboard.rows
+        if hasattr(row.user, 'displayName')
+    }
+
+    # Process existing users.
+    for user in spreadsheet[0][1:]:
+        try:
+            column.append(str(round(int(commitments.pop(user, '-')) / SECONDS_IN_HOUR)))
+        except TypeError:
+            column.append('-')
+
+    # Process the users that don't exist in the spreadsheet yet.
+    for user, commitment in commitments.items():
+        users.append(user)
+        column.append(str(round(commitment / SECONDS_IN_HOUR)))
+
+    return users, column
+
+
+def get_commitment_range(spreadsheet: List[List[str]], cell_name: str) -> str:
+    """Retrieve the proper range for the spreadsheet, depending on the cell and number of currently stored sprints."""
+    column_number = base_10_to_n(len(spreadsheet), len(string.ascii_uppercase))
+    return f"'{cell_name} Commitments'!{column_number}3"
+
+
+def base_10_to_n(num: int, b: int, numerals: str = string.ascii_uppercase) -> str:
+    """Convert `num` to the desired base `b` with selected `numerals`"""
+    return ((num == 0) and numerals[0]) or (base_10_to_n(num // b, b, numerals).lstrip(numerals[0]) + numerals[num % b])


### PR DESCRIPTION
This adds exporting the users' commitments at the end of the sprint into the Google Spreadsheet.

## Testing instructions:
1. Set `.env` file.
1. Start the backend with `docker-compose -f local.yml up --build`.
1. Create superuser with `docker-compose -f local.yml run --rm django python manage.py createsuperuser` (the button on frontend will be visible for `staff` users only).
1. Add email to your superuser account under `http://localhost:8000/admin/account/emailaddress/`.
1. Navigate to `frontend` and run `npm i && npm start`.
1. Log into the frontend.
1. Click the red `Complete Sprints` button and confirm it.
1. Wait for the task to finish (it takes around a minute, because we need to run group of tasks synchronously, as using Celery 4 with Redis [seems to be broken](https://github.com/celery/celery/issues/4925)).
1. Check `${CELL} Commitments` sheets in the dev spillover spreadsheet.