### PR TITLE
[BB-1547] Add single-user view

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
       - run:
           name: Create .env file
           command: |
-            echo -e "REACT_APP_API_BASE=$REACT_APP_API_BASE\nREACT_APP_GOOGLE_CLIENT_ID=$REACT_APP_GOOGLE_CLIENT_ID" > frontend/.env.production
+            echo -e "REACT_APP_API_BASE=$REACT_APP_API_BASE\nREACT_APP_GOOGLE_CLIENT_ID=$REACT_APP_GOOGLE_CLIENT_ID\nJIRA_URL=$JIRA_URL" > frontend/.env.production
       - restore_cache:
           key: dependency-cache-{{ checksum "frontend/package.json" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,9 @@ jobs:
       - run:
           name: Create .env file
           command: |
-            echo -e "REACT_APP_API_BASE=$REACT_APP_API_BASE\nREACT_APP_GOOGLE_CLIENT_ID=$REACT_APP_GOOGLE_CLIENT_ID\nJIRA_URL=$JIRA_URL" > frontend/.env.production
+            echo "REACT_APP_API_BASE=$REACT_APP_API_BASE" >> frontend/.env.production
+            echo "REACT_APP_GOOGLE_CLIENT_ID=$REACT_APP_GOOGLE_CLIENT_ID" >> frontend/.env.production
+            echo "REACT_APP_JIRA_URL=$REACT_APP_JIRA_URL" >> frontend/.env.production
       - restore_cache:
           key: dependency-cache-{{ checksum "frontend/package.json" }}
       - run:

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -334,6 +334,7 @@ JIRA_SPRINT_BOARD_PREFIX = env.str("SPRINT_BOARD_PREFIX", "Sprint - ")
 JIRA_BOT_USERNAME = env.str("JIRA_BOT_USERNAME", "crafty")
 JIRA_REQUIRED_FIELDS = (
     "Assignee",
+    "Summary",
     "Description",
     "Issue Type",
     "Status",

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,3 @@
 REACT_APP_API_BASE=http://localhost:8000
 REACT_APP_GOOGLE_CLIENT_ID=SET_THIS
+JIRA_URL=https://jira.server

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,3 +1,3 @@
 REACT_APP_API_BASE=http://localhost:8000
 REACT_APP_GOOGLE_CLIENT_ID=SET_THIS
-JIRA_URL=https://jira.server
+REACT_APP_JIRA_URL=https://jira.server

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10237,6 +10237,16 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
+    "query-string": {
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.2.tgz",
+      "integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -11778,6 +11788,11 @@
         "wbuf": "^1.7.3"
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -11936,6 +11951,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-length": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "bootstrap": "^4.3.1",
+    "query-string": "^6.8.2",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-google-login": "^5.0.5",

--- a/frontend/src/actions/auth.js
+++ b/frontend/src/actions/auth.js
@@ -1,4 +1,4 @@
-const PATH_BASE = `${process.env.REACT_APP_API_BASE}/rest-auth`;
+import {PATH_GOOGLE, PATH_LOGIN, PATH_LOGOUT, PATH_REGISTER, PATH_USER, PATH_VERIFY_EMAIL} from "../constants";
 
 export const loadUser = () => {
     return (dispatch, getState) => {
@@ -13,7 +13,7 @@ export const loadUser = () => {
         if (token) {
             headers["Authorization"] = `JWT ${token}`;
         }
-        return fetch(PATH_BASE + "/user/", {headers, })
+        return fetch(PATH_USER, {headers,})
             .then(res => {
                 if (res.status < 500) {
                     return res.json().then(data => {
@@ -26,7 +26,7 @@ export const loadUser = () => {
             })
             .then(res => {
                 if (res.status === 200) {
-                    dispatch({type: 'USER_LOADED', user: res.data });
+                    dispatch({type: 'USER_LOADED', user: res.data});
                     return res.data;
                 } else if (res.status >= 400 && res.status < 500) {
                     dispatch({type: "AUTHENTICATION_ERROR", data: res.data});
@@ -34,14 +34,14 @@ export const loadUser = () => {
                 }
             })
     }
-}
+};
 
 export const login = (email, password) => {
     return (dispatch, getState) => {
         let headers = {"Content-Type": "application/json"};
         let body = JSON.stringify({email, password});
 
-        return fetch(PATH_BASE + "/login/", {headers, body, method: "POST"})
+        return fetch(PATH_LOGIN, {headers, body, method: "POST"})
             .then(res => {
                 if (res.status < 500) {
                     return res.json().then(data => {
@@ -72,7 +72,7 @@ export const social_login = (access_token) => {
         let headers = {"Content-Type": "application/json"};
         let body = JSON.stringify({access_token});
 
-        return fetch(PATH_BASE + "/google/", {headers, body, method: "POST"})
+        return fetch(PATH_GOOGLE, {headers, body, method: "POST"})
             .then(res => {
                 if (res.status < 500) {
                     return res.json().then(data => {
@@ -103,7 +103,7 @@ export const register = (email, password1, password2) => {
         let headers = {"Content-Type": "application/json"};
         let body = JSON.stringify({email, password1, password2});
 
-        return fetch(PATH_BASE + "/registration/", {headers, body, method: "POST"})
+        return fetch(PATH_REGISTER, {headers, body, method: "POST"})
             .then(res => {
                 if (res.status < 500) {
                     return res.json().then(data => {
@@ -133,7 +133,7 @@ export const logout = () => {
     return (dispatch, getState) => {
         let headers = {"Content-Type": "application/json"};
 
-        return fetch(PATH_BASE + "/logout/", {headers, body: "", method: "POST"})
+        return fetch(PATH_LOGOUT, {headers, body: "", method: "POST"})
             .then(res => {
                 if (res.status === 200) {
                     return {status: res.status, data: {}};
@@ -163,7 +163,7 @@ export const verify_email = (key) => {
         let headers = {"Content-Type": "application/json"};
         let body = JSON.stringify({key});
 
-        return fetch(PATH_BASE + "/registration/verify-email/", {headers, body, method: "POST"})
+        return fetch(PATH_VERIFY_EMAIL, {headers, body, method: "POST"})
             .then(res => {
                 if (res.status < 500) {
                     return res.json().then(data => {

--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -1,3 +1,5 @@
 import * as auth from "./auth";
+import * as sprints from "./sprints";
 
 export {auth}
+export {sprints}

--- a/frontend/src/actions/sprints.js
+++ b/frontend/src/actions/sprints.js
@@ -1,0 +1,81 @@
+import {PARAM_BOARD_ID, PATH_CELLS, PATH_DASHBOARD} from "../constants";
+
+export const loadCells = () => {
+    return (dispatch, getState) => {
+        dispatch({type: "CELLS_LOADING"});
+
+        let token = getState().auth.token;
+        let headers = {
+            "Content-Type": "application/json",
+        };
+        if (token) {
+            headers["Authorization"] = `JWT ${token}`;
+        }
+
+        return fetch(PATH_CELLS, {headers,})
+            .then(response => {
+                if (response.status < 500) {
+                    return response.json().then(data => {
+                        return {status: response.status, data};
+                    })
+                } else {
+                    console.log("Server Error!");
+                    throw response;
+                }
+            })
+            .then(result => {
+                if (result.status === 200) {
+                    dispatch({type: 'CELLS_LOADED', cells: result.data});
+                    return result.data;
+                } else if (result.status >= 400 && result.status < 500) {
+                    dispatch({type: "AUTHENTICATION_ERROR", data: result.data});
+                    throw result.data;
+                }
+            });
+    }
+};
+
+export const loadBoard = (board_id) => {
+    let board_url = `${PATH_DASHBOARD}?${PARAM_BOARD_ID}${board_id}`;
+
+    return (dispatch, getState) => {
+        dispatch({type: "BOARD_LOADING", board_id: board_id});
+
+        let token = getState().auth.token;
+        let headers = {
+            "Content-Type": "application/json",
+        };
+        if (token) {
+            headers["Authorization"] = `JWT ${token}`;
+        }
+
+        return fetch(board_url, {headers,})
+            .then(response => {
+                if (response.status < 500) {
+                    return response.json().then(data => {
+                        return {status: response.status, data};
+                    })
+                } else {
+                    console.log("Server Error!");
+                    throw response;
+                }
+            })
+            .then(result => {
+                if (result.status === 200) {
+                    result.data.rows.sort((x, y) => (x.name > y.name) ? 1 : -1);
+                    result.data.issues.sort((x, y) => {
+                        if (x.current_sprint !== y.current_sprint) {
+                            return (x.current_sprint > y.current_sprint) ? -1 : 1
+                        }
+                        return (x.key > y.key) ? 1 : -1
+                    });
+
+                    dispatch({type: 'BOARD_LOADED', board_id: board_id, data: result.data});
+                    return result.data;
+                } else if (result.status >= 400 && result.status < 500) {
+                    dispatch({type: "AUTHENTICATION_ERROR", data: result.data});
+                    throw result.data;
+                }
+            });
+    }
+};

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -1,0 +1,69 @@
+import React, {Component} from "react";
+import Table from "./Table";
+import {connect} from "react-redux";
+import {auth, sprints} from "../actions";
+
+class Board extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            board_id: this.props.match.params.board_id,
+        };
+    }
+
+    componentDidMount() {
+        this.props.loadBoard(this.state.board_id);
+    }
+
+    render() {
+        const {boardLoading, boards} = this.props.sprints;
+        const board = boards[this.state.board_id] || {};
+        const {rows, future_sprint} = board;
+        const url = this.props.match.url.replace(/\/$/, '');  // Remove trailing slash, if needed.
+
+        return (
+            <div className='dashboard'>
+                {
+                    rows && rows.length
+                        ? <div>
+                            {
+                                boardLoading
+                                    ? <div className="loading">
+                                        <div className="spinner-border"/>
+                                        <p>You are viewing the cached version now. The dashboard is being reloaded…</p>
+                                    </div>
+                                    : <div/>
+                            }
+                            <h2>Commitments for Upcoming Sprint - {future_sprint}</h2>
+                            <Table list={rows} url={url}/>
+                        </div>
+                        : <div>
+                            <div className="spinner-border"/>
+                            <p>Loading the dashboard…</p>
+                        </div>
+                }
+            </div>
+        );
+    }
+}
+
+const mapStateToProps = state => {
+    return {
+        auth: state.auth,
+        sprints: state.sprints,
+    }
+};
+
+const mapDispatchToProps = dispatch => {
+    return {
+        loadUser: () => {
+            return dispatch(auth.loadUser());
+        },
+        loadBoard: (board_id) => {
+            return dispatch(sprints.loadBoard(board_id));
+        }
+    }
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Board);

--- a/frontend/src/components/Cells.js
+++ b/frontend/src/components/Cells.js
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, {Component} from 'react';
 import {Link} from "react-router-dom";
+import {connect} from "react-redux";
+import {auth, sprints} from "../actions";
 
-const Cells = ({list}) =>
+
+const CellsList = ({list}) =>
     <ul>
         {list.map(item =>
             <li key={item.name}>
@@ -10,4 +13,44 @@ const Cells = ({list}) =>
         )}
     </ul>;
 
-export default Cells;
+class Cells extends Component {
+    componentDidMount() {
+        this.props.loadCells();
+    }
+
+    render() {
+        const {cells} = this.props.sprints;
+        return (
+            <div className='cells'>
+                {
+                    cells && cells.length
+                        ? <CellsList list={cells}/>
+                        : <div>
+                            <div className="spinner-border"/>
+                            <p>Loading the list of cells…</p>
+                        </div>
+                }
+            </div>
+        );
+    }
+}
+
+const mapStateToProps = state => {
+    return {
+        auth: state.auth,
+        sprints: state.sprints,
+    }
+};
+
+const mapDispatchToProps = dispatch => {
+    return {
+        loadUser: () => {
+            return dispatch(auth.loadUser());
+        },
+        loadCells: () => {
+            return dispatch(sprints.loadCells());
+        }
+    }
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Cells);

--- a/frontend/src/components/CompleteSprintsButton.js
+++ b/frontend/src/components/CompleteSprintsButton.js
@@ -1,8 +1,6 @@
 import {connect} from "react-redux";
 import React, {Component} from 'react';
-
-const PATH_COMPLETE_SPRINTS = `${process.env.REACT_APP_API_BASE}/dashboard/complete_sprints/`;
-
+import {PATH_COMPLETE_SPRINTS} from "../constants";
 
 class CompleteSprintsButton extends Component {
     completeSprints = () => {

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -4,6 +4,7 @@ import {connect} from "react-redux";
 import {Link, Redirect} from "react-router-dom";
 import {auth} from "../actions";
 import GoogleLogin from "react-google-login";
+import * as qs from "query-string";
 
 
 class Login extends Component {
@@ -23,7 +24,9 @@ class Login extends Component {
 
     render() {
         if (this.props.isAuthenticated) {
-            return <Redirect to="/"/>
+            // Redirect to the original link instead of the main page.
+            const redirect = qs.parse(this.props.location.search).next || "/";
+            return <Redirect to={redirect}/>
         }
         return (
             <form onSubmit={this.onSubmit}>

--- a/frontend/src/components/Table.css
+++ b/frontend/src/components/Table.css
@@ -64,3 +64,8 @@ tr:hover td {
   background: #ffffaa;
   color: #222222;
 }
+
+.loading {
+  color: #737a7a;
+  font-size: smaller;
+}

--- a/frontend/src/components/Table.js
+++ b/frontend/src/components/Table.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import './Table.css';
+import {Link} from "react-router-dom";
+import {PATH_JIRA_ISSUE} from "../constants";
 
 const nameColumn = {width: '20%'};  // 1 cell
 const spilloverColumn = {width: '28%'};   // 1 cell
@@ -7,9 +9,7 @@ const newWorkColumn = {width: '52%'};   // 1 cell
 const timeColumn = {width: '6%'};  // 10 cells -> 60% total
 const unestimatedColumn = {width: '10%'};  // 2 cells -> 20% total
 
-const ISSUE_PATH = 'https://tasks.opencraft.com/browse/';  // TODO: Move this to config.
-
-const Table = ({list}) =>
+const Table = ({list, url}) =>
     <table className="table">
         <thead>
         <tr className="table-header">
@@ -67,7 +67,7 @@ const Table = ({list}) =>
         {list.map(item =>
             <tr key={item.name} className="table-row">
                 <td style={nameColumn}>
-                    {item.name}
+                    <Link to={`${url}/user/${item.name}`}>{item.name}</Link>
                 </td>
                 <td style={timeColumn}>
                     {Math.round(item.current_remaining_assignee_time / 3600)}
@@ -81,15 +81,15 @@ const Table = ({list}) =>
                 <td style={unestimatedColumn}>
                     {item.current_unestimated.map(ticket =>
                         <li key={ticket}>
-                            <a href={ISSUE_PATH + ticket} target="_blank" rel="noopener noreferrer">{ticket}</a>
+                            <a href={PATH_JIRA_ISSUE + ticket} target="_blank" rel="noopener noreferrer">{ticket}</a>
                         </li>
                     )}
                 </td>
                 <td style={timeColumn}>
-                    {Math.round(item.future_remaining_assignee_time / 3600)}
+                    {Math.round(item.future_assignee_time / 3600)}
                 </td>
                 <td style={timeColumn}>
-                    {Math.round(item.future_remaining_review_time / 3600)}
+                    {Math.round(item.future_review_time / 3600)}
                 </td>
                 <td style={timeColumn}>
                     {Math.round(item.future_epic_management_time / 3600)}
@@ -97,7 +97,7 @@ const Table = ({list}) =>
                 <td style={unestimatedColumn}>
                     {item.future_unestimated.map(ticket =>
                         <li key={ticket}>
-                            <a href={ISSUE_PATH + ticket} target="_blank" rel="noopener noreferrer">{ticket}</a>
+                            <a href={PATH_JIRA_ISSUE + ticket} target="_blank" rel="noopener noreferrer">{ticket}</a>
                         </li>
                     )}
                 </td>

--- a/frontend/src/components/UserBoard.js
+++ b/frontend/src/components/UserBoard.js
@@ -1,0 +1,76 @@
+import React, {Component} from "react";
+import {connect} from "react-redux";
+import {auth, sprints} from "../actions";
+import UserTable from "./UserTable";
+
+class UserBoard extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            board_id: this.props.match.params.board_id,
+            username: this.props.match.params.username,
+        };
+    }
+
+    componentDidMount() {
+        this.props.loadBoard(this.state.board_id);
+    }
+
+    filterIssues(issues) {
+        return issues.filter(el => el.assignee === this.state.username || el.reviewer_1 === this.state.username);
+    }
+
+    render() {
+        const username = this.state.username;
+        const {boardLoading, boards} = this.props.sprints;
+        const board = boards[this.state.board_id] || {};
+
+        const {issues} = board;
+        const user_issues = this.filterIssues(issues);
+
+        return (
+            <div className='dashboard'>
+                {
+                    user_issues && user_issues.length
+                        ? <div>
+                            {
+                                boardLoading
+                                    ? <div className="loading">
+                                        <div className="spinner-border"/>
+                                        <p>You are viewing the cached version now. The dashboard is being reloaded…</p>
+                                    </div>
+                                    : <div/>
+                            }
+                            <h2>Commitments of {username} for the current and upcoming sprint</h2>
+                            <UserTable list={user_issues} username={username}/>
+                        </div>
+                        : <div>
+                            <div className="spinner-border"/>
+                            <p>Loading the dashboard…</p>
+                        </div>
+                }
+            </div>
+        );
+    }
+}
+
+const mapStateToProps = state => {
+    return {
+        auth: state.auth,
+        sprints: state.sprints,
+    }
+};
+
+const mapDispatchToProps = dispatch => {
+    return {
+        loadUser: () => {
+            return dispatch(auth.loadUser());
+        },
+        loadBoard: (board_id) => {
+            return dispatch(sprints.loadBoard(board_id));
+        }
+    }
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(UserBoard);

--- a/frontend/src/components/UserTable.js
+++ b/frontend/src/components/UserTable.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import './Table.css';
+import {PATH_JIRA_ISSUE} from "../constants";
+
+const nameColumn = {width: '20%'};  // 2 cells -> 40%
+const timeColumn = {width: '10%'};  // 6 cells -> 60% total
+
+const UserTable = ({list, username}) =>
+    <table className="table">
+        <thead>
+        <tr className="table-header">
+            <td style={timeColumn}>
+                Key
+            </td>
+            <td style={nameColumn}>
+                Assignee
+            </td>
+            <td style={nameColumn}>
+                Reviewer 1
+            </td>
+            <td style={timeColumn}>
+                Status
+            </td>
+            <td style={timeColumn}>
+                Assignee Time
+            </td>
+            <td style={timeColumn}>
+                Reviewer Time
+            </td>
+            <td style={timeColumn}>
+                Current Sprint
+            </td>
+            <td style={timeColumn}>
+                Is Epic
+            </td>
+        </tr>
+        </thead>
+        <tbody>
+        {list.map(item =>
+            <tr key={item.key} className={"table-row"}>
+                <td style={timeColumn}>
+                    <a href={PATH_JIRA_ISSUE + item.key} title={item.summary} target="_blank"
+                       rel="noopener noreferrer">{item.key}</a>
+                </td>
+                <td style={nameColumn}>
+                    {item.assignee}
+                </td>
+                <td style={nameColumn}>
+                    {item.reviewer_1}
+                </td>
+                <td style={timeColumn}>
+                    {item.status}
+                </td>
+                <td style={timeColumn}>
+                    {
+                        item.assignee === username
+                            ? Math.round(item.assignee_time / 3600)
+                            : null
+                    }
+                </td>
+                <td style={timeColumn}>
+                    {
+                        item.reviewer_1 === username
+                            ? Math.round(item.review_time / 3600)
+                            : null
+                    }
+                </td>
+                <td style={timeColumn}>
+                    {
+                        item.current_sprint
+                            ? "✔"
+                            : ""
+                    }
+                </td>
+                <td style={timeColumn}>
+                    {
+                        item.is_epic
+                            ? "✔"
+                            : ""
+                    }
+                </td>
+            </tr>,
+        )}
+        </tbody>
+    </table>;
+
+export default UserTable;

--- a/frontend/src/components/UserTable.js
+++ b/frontend/src/components/UserTable.js
@@ -2,8 +2,8 @@ import React from 'react';
 import './Table.css';
 import {PATH_JIRA_ISSUE} from "../constants";
 
-const nameColumn = {width: '20%'};  // 2 cells -> 40%
-const timeColumn = {width: '10%'};  // 6 cells -> 60% total
+const nameColumn = {width: '25%'};  // 1 cells -> 25% total
+const timeColumn = {width: '15%'};  // 5 cells -> 75% total
 
 const UserTable = ({list, username}) =>
     <table className="table">
@@ -12,20 +12,14 @@ const UserTable = ({list, username}) =>
             <td style={timeColumn}>
                 Key
             </td>
-            <td style={nameColumn}>
-                Assignee
-            </td>
-            <td style={nameColumn}>
-                Reviewer 1
-            </td>
             <td style={timeColumn}>
+                Working As
+            </td>
+            <td style={nameColumn}>
                 Status
             </td>
             <td style={timeColumn}>
-                Assignee Time
-            </td>
-            <td style={timeColumn}>
-                Reviewer Time
+                Remaining Time
             </td>
             <td style={timeColumn}>
                 Current Sprint
@@ -42,27 +36,21 @@ const UserTable = ({list, username}) =>
                     <a href={PATH_JIRA_ISSUE + item.key} title={item.summary} target="_blank"
                        rel="noopener noreferrer">{item.key}</a>
                 </td>
-                <td style={nameColumn}>
-                    {item.assignee}
-                </td>
-                <td style={nameColumn}>
-                    {item.reviewer_1}
-                </td>
                 <td style={timeColumn}>
+                    {
+                        item.assignee === username
+                            ? "Assignee"
+                            : "Reviewer"
+                    }
+                </td>
+                <td style={nameColumn}>
                     {item.status}
                 </td>
                 <td style={timeColumn}>
                     {
                         item.assignee === username
                             ? Math.round(item.assignee_time / 3600)
-                            : null
-                    }
-                </td>
-                <td style={timeColumn}>
-                    {
-                        item.reviewer_1 === username
-                            ? Math.round(item.review_time / 3600)
-                            : null
+                            : Math.round(item.review_time / 3600)
                     }
                 </td>
                 <td style={timeColumn}>

--- a/frontend/src/constants/index.js
+++ b/frontend/src/constants/index.js
@@ -1,0 +1,17 @@
+export const PATH_BASE = `${process.env.REACT_APP_API_BASE}`;
+
+export const PATH_AUTH = `${PATH_BASE}/rest-auth`;
+export const PATH_USER = `${PATH_AUTH}/user/`;
+export const PATH_LOGIN = `${PATH_AUTH}/login/`;
+export const PATH_REGISTER = `${PATH_AUTH}/registration/`;
+export const PATH_GOOGLE = `${PATH_AUTH}/google/`;
+export const PATH_LOGOUT = `${PATH_AUTH}/logout/`;
+export const PATH_VERIFY_EMAIL = `${PATH_AUTH}/registration/verify-email/`;
+
+export const PATH_BASE_DASHBOARD = `${PATH_BASE}/dashboard`;
+export const PATH_CELLS = `${PATH_BASE_DASHBOARD}/cells/`;
+export const PATH_DASHBOARD = `${PATH_BASE_DASHBOARD}/dashboard/`;
+export const PARAM_BOARD_ID = 'board_id=';
+
+export const PATH_JIRA_BASE = `${process.env.JIRA_URL}`;
+export const PATH_JIRA_ISSUE = `${PATH_JIRA_BASE}/browse/`;

--- a/frontend/src/constants/index.js
+++ b/frontend/src/constants/index.js
@@ -12,6 +12,7 @@ export const PATH_BASE_DASHBOARD = `${PATH_BASE}/dashboard`;
 export const PATH_CELLS = `${PATH_BASE_DASHBOARD}/cells/`;
 export const PATH_DASHBOARD = `${PATH_BASE_DASHBOARD}/dashboard/`;
 export const PARAM_BOARD_ID = 'board_id=';
+export const PATH_COMPLETE_SPRINTS = `${PATH_BASE_DASHBOARD}/complete_sprints/`;
 
-export const PATH_JIRA_BASE = `${process.env.JIRA_URL}`;
+export const PATH_JIRA_BASE = `${process.env.REACT_APP_JIRA_URL}`;
 export const PATH_JIRA_ISSUE = `${PATH_JIRA_BASE}/browse/`;

--- a/frontend/src/reducers/index.js
+++ b/frontend/src/reducers/index.js
@@ -1,9 +1,9 @@
 import {combineReducers} from 'redux';
 import auth from "./auth";
+import sprints from "./sprints";
 
 
-const sprints_reducers = combineReducers({
+export default combineReducers({
     auth,
+    sprints,
 });
-
-export default sprints_reducers;

--- a/frontend/src/reducers/sprints.js
+++ b/frontend/src/reducers/sprints.js
@@ -1,0 +1,39 @@
+const initialState = {
+    cellsLoading: true,
+    boardLoading: true,
+    cells: JSON.parse(localStorage.getItem("cells")) || [],
+    boards: JSON.parse(localStorage.getItem("boards")) || {},
+};
+
+
+export default function sprints(state=initialState, action) {
+    let board;
+
+    switch (action.type) {
+
+        case 'CELLS_LOADING':
+            return {...state, cellsLoading: true};
+
+        case 'BOARD_LOADING':
+            return {...state, boardLoading: true};
+
+        case 'CELLS_LOADED':
+            localStorage.setItem("cells", JSON.stringify(action.cells));
+            return {...state, cellsLoading: false, cells: action.cells};
+
+        case 'BOARD_LOADED':
+            const {future_sprint, rows, issues} = action.data;
+
+            board = state.boards[action.board_id] || {};
+            board.future_sprint = future_sprint;
+            board.rows = rows;
+            board.issues = issues;
+
+            state.boards[action.board_id] = board;
+            localStorage.setItem("boards", JSON.stringify(state.boards));
+            return {...state, boardLoading: false};
+
+        default:
+            return state;
+    }
+}

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -1,6 +1,7 @@
 export default {
     cells: "/",
     board: "/board/:board_id",
+    user_board: "/board/:board_id/user/:username",
     login: "/login",
     register: "/register",
     verify_email: "/verify-email/:key",

--- a/local.yml
+++ b/local.yml
@@ -21,6 +21,8 @@ services:
       - ./.env
     ports:
       - "8000:8000"
+    stdin_open: true
+    tty: true
     command: /start
 
   postgres:

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -2,6 +2,7 @@
 
 Werkzeug==0.15.4  # https://github.com/pallets/werkzeug
 ipdb==0.12  # https://github.com/gotcha/ipdb
+pdbpp==0.10.0  # https://github.com/pdbpp/pdbpp
 Sphinx==2.0.1  # https://github.com/sphinx-doc/sphinx
 psycopg2==2.8 --no-binary psycopg2  # https://github.com/psycopg/psycopg2
 

--- a/sprints/dashboard/serializers.py
+++ b/sprints/dashboard/serializers.py
@@ -1,10 +1,8 @@
-from jira import (
-    User as JiraUser,
-)
 from rest_framework import serializers
 
 from sprints.dashboard.models import (
     Dashboard,
+    DashboardIssue,
     DashboardRow,
 )
 
@@ -17,14 +15,41 @@ class CellSerializer(serializers.Serializer):
 
 
 # noinspection PyAbstractClass
+class DashboardIssueSerializer(serializers.Serializer):
+    """Serializer for dashboard issue."""
+    key = serializers.CharField()
+    summary = serializers.CharField()
+    assignee = serializers.SerializerMethodField()
+    reviewer_1 = serializers.SerializerMethodField()
+    current_sprint = serializers.BooleanField()
+    is_epic = serializers.BooleanField()
+    status = serializers.CharField()
+    assignee_time = serializers.SerializerMethodField()
+    review_time = serializers.IntegerField()
+
+    # noinspection PyMethodMayBeStatic
+    def get_assignee(self, obj: DashboardIssue):
+        return obj.assignee.displayName
+
+    # noinspection PyMethodMayBeStatic
+    def get_reviewer_1(self, obj: DashboardIssue):
+        return obj.reviewer_1.displayName
+
+    # noinspection PyMethodMayBeStatic
+    def get_assignee_time(self, obj: DashboardIssue):
+        """Aggregates assignee, recurring and epic management time for easier data reading."""
+        return obj.assignee_time + obj.recurring_time + obj.epic_management_time  # type: ignore
+
+
+# noinspection PyAbstractClass
 class DashboardRowSerializer(serializers.Serializer):
-    """Serializer for dashboard rows."""
+    """Serializer for dashboard row."""
     name = serializers.SerializerMethodField()
     current_remaining_assignee_time = serializers.IntegerField()
     current_remaining_review_time = serializers.IntegerField()
     current_remaining_upstream_time = serializers.IntegerField()
-    future_remaining_assignee_time = serializers.IntegerField()
-    future_remaining_review_time = serializers.IntegerField()
+    future_assignee_time = serializers.IntegerField()
+    future_review_time = serializers.IntegerField()
     future_epic_management_time = serializers.IntegerField()
     committed_time = serializers.IntegerField()
     goal_time = serializers.IntegerField()
@@ -35,17 +60,14 @@ class DashboardRowSerializer(serializers.Serializer):
 
     # noinspection PyMethodMayBeStatic
     def get_name(self, obj: DashboardRow):
-        if isinstance(obj.user, JiraUser):
-            return obj.user.displayName
-        elif obj.user:
-            return "Unassigned"
-        return obj.user
+        return obj.user.displayName
 
 
 # noinspection PyAbstractClass
 class DashboardSerializer(serializers.Serializer):
     """Serializer for the dashboard."""
     rows = DashboardRowSerializer(many=True)
+    issues = DashboardIssueSerializer(many=True)
     future_sprint = serializers.SerializerMethodField()
 
     # noinspection PyMethodMayBeStatic

--- a/sprints/dashboard/utils.py
+++ b/sprints/dashboard/utils.py
@@ -11,6 +11,7 @@ from typing import (
     List,
     Union,
     Tuple,
+    Optional,
 )
 
 from dateutil.parser import parse
@@ -182,14 +183,15 @@ def get_sprint_end_date(sprint: Sprint, sprints: List[Sprint]) -> str:
     return get_sprint_start_date(future_sprint)
 
 
-def prepare_jql_query(sprints: List[str], fields: List[str]) -> Dict[str, Union[str, List[str]]]:
+def prepare_jql_query(sprints: List[str], fields: List[str], user: Optional[str] = None) -> Dict[str, Union[str, List[str]]]:
     """Prepare JQL query for retrieving stories and epics for the selected cell for the current and upcoming sprint."""
     unfinished_status = '"' + '","'.join(settings.SPRINT_STATUS_ACTIVE) + '"'
     epic_in_progress = '"' + '","'.join(settings.SPRINT_STATUS_EPIC_IN_PROGRESS) + '"'
     sprints_str = ','.join(sprints)
+    user_str = f'(assignee = "{user}" OR "Reviewer 1" = "{user}") AND ' if user else ''
 
-    query = f'(Sprint IN ({sprints_str}) AND ' \
-            f'status IN ({unfinished_status})) OR (issuetype = Epic AND Status IN ({epic_in_progress}))'
+    query = f'({user_str}Sprint IN ({sprints_str}) AND ' \
+            f'status IN ({unfinished_status})) OR ({user_str}issuetype = Epic AND Status IN ({epic_in_progress}))'
 
     return {
         'jql_str': query,


### PR DESCRIPTION
This introduces the whole new view for the user - the single-user view, which shows the assignments for the particular user. To make the user-experience smooth here, some bigger reworks were required, i.e.:
- moving the cell/board data to Redux and caching it in Local Storage - thanks to this we can now browse smoothly between the dashboards and users, while the data is being fetched in the background and the dashboard is being updated dynamically,
- adding issues to the dashboard's serializer, because we originally had them on the backend side and we don't need to fetch them for each user (we're now just doing it to maintain the up-to-date status of the board).

## Testing instructions:
1. Set `.env` file.
1. Set `JIRA_URL` and `REACT_APP_GOOGLE_CLIENT_ID` in `frontend/.env.local` file.
1. Start the backend with `docker-compose -f local.yml up --build`.
1. Navigate to `frontend` and run `npm i && npm start`.
1. Log into the frontend.
1. Open the cell's board and wait for it to fetch.
1. Go to your user's board and count that the values match the ones from the cell's board (and the actual state of your commitments).
1. Go back and forth between different views to confirm that the cache works properly.