### PR TITLE
[BB-1625] Rework retrieving accounts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   aws-s3: circleci/aws-s3@1.0.11
 
 jobs:
-  test:
+  test_backend:
     docker:
       - image: circleci/python:3.7
         environment:
@@ -40,6 +40,24 @@ jobs:
             coverage run -m pytest
             coverage report
 
+  test_frontend:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "frontend/package.json" }}
+      - run:
+          name: Install dependencies
+          command: "cd frontend && npm install"
+      - save_cache:
+          key: dependency-cache-{{ checksum "frontend/package.json" }}
+          paths:
+            - ./frontend/node_modules
+      - run:
+          name: Run tests
+          command: "cd frontend && npm run-script test-ci"
+
   build_backend:
     docker:
       - image: circleci/python:3.7
@@ -63,7 +81,7 @@ jobs:
 
   build_frontend:
     docker:
-      - image: circleci/node:11.15
+      - image: circleci/node:12
     steps:
       - checkout
       - run:
@@ -117,17 +135,20 @@ workflows:
   version: 2
   main:
     jobs:
-      - test
+      - test_backend
+      - test_frontend
 
       - build_backend:
           requires:
-            - test
+            - test_backend
+            - test_frontend
           filters:
             branches:
               only: master
       - build_frontend:
           requires:
-            - test
+            - test_backend
+            - test_frontend
           filters:
             branches:
               only: master

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -334,6 +334,8 @@ JIRA_PASSWORD = env.str("JIRA_PASSWORD")
 JIRA_SPRINT_BOARD_PREFIX = env.str("SPRINT_BOARD_PREFIX", "Sprint - ")
 # Username of a helper Jira bot used for indicating custom review time requirements.
 JIRA_BOT_USERNAME = env.str("JIRA_BOT_USERNAME", "crafty")
+# Date format used by the Jira API.
+JIRA_API_DATE_FORMAT = env.str("JIRA_API_DATE_FORMAT", "%Y-%m-%d")
 JIRA_REQUIRED_FIELDS = (
     "Assignee",
     "Summary",
@@ -460,8 +462,22 @@ SPILLOVER_REMINDER_MESSAGE = fr"please fill the spillover reason in the " \
 
 # Specify names of the Tempo account categories.
 TEMPO_BILLABLE_ACCOUNT = env.str("TEMPO_BILLABLE_ACCOUNT", "BILLABLE")
+TEMPO_BILLABLE_ACCOUNT_NAME = env.str("TEMPO_BILLABLE_ACCOUNT_NAME", "Billable account")
 TEMPO_NON_BILLABLE_ACCOUNT = env.str("TEMPO_NON_BILLABLE_ACCOUNT", "NON-BILLABLE")
+TEMPO_NON_BILLABLE_ACCOUNT_NAME = env.str("TEMPO_NON_BILLABLE_ACCOUNT_NAME", "Non-billable account")
 TEMPO_NON_BILLABLE_RESPONSIBLE_ACCOUNT = env.str("TEMPO_NON_BILLABLE_RESPONSIBLE_ACCOUNT", "NON-BILLABLE-CELL")
+TEMPO_NON_BILLABLE_RESPONSIBLE_ACCOUNT_NAME = env.str("TEMPO_NON_BILLABLE_RESPONSIBLE_ACCOUNT_NAME", "Non-billable cell responsibility account")
+
+# Dict for local account naming.
+TEMPO_ACCOUNT_TRANSLATE = {
+    TEMPO_BILLABLE_ACCOUNT_NAME: 'billable_accounts',
+    TEMPO_NON_BILLABLE_ACCOUNT_NAME: 'non_billable_accounts',
+    TEMPO_NON_BILLABLE_RESPONSIBLE_ACCOUNT_NAME: 'non_billable_responsible_accounts',
+}
+
+# Base TEMPO Team ID
+TEMPO_TEAM_ID = env.int("TEMPO_TEAM_ID", 1)
 
 # Pool size for making parallel API requests
-MULTIPROCESSING_POOL_SIZE = env.int("MULTIPROCESSING_POOL_SIZE", 6)
+MULTIPROCESSING_POOL_SIZE = env.int("MULTIPROCESSING_POOL_SIZE", 32)
+MULTIPROCESSING_TIMEOUT = env.int("MULTIPROCESSING_TIMEOUT", 32)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11007,6 +11007,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
+    },
     "resolve": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,12 +15,14 @@
     "react-scripts": "3.1.1",
     "reactstrap": "^8.0.1",
     "redux": "^4.0.4",
-    "redux-thunk": "^2.3.0"
+    "redux-thunk": "^2.3.0",
+    "reselect": "^4.0.0"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "test-ci": "CI=true react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/frontend/src/actions/sustainability.js
+++ b/frontend/src/actions/sustainability.js
@@ -6,18 +6,12 @@ const aggregateAccounts = (data) => {
     Object.entries(data).forEach(([account_type, accounts]) => {
         result[account_type] = {
             'overall': 0,
-            'by_cell': {},
             'by_person': {},
         };
 
         accounts.forEach(account => {
             // Calculate overall.
             result[account_type].overall = (result[account_type].overall || 0) + account.overall;
-
-            // Calculate for each cell.
-            Object.entries(account.by_cell).forEach(([cell, hours]) => {
-                result[account_type].by_cell[cell] = (result[account_type].by_cell[cell] || 0) + hours;
-            });
 
             // Calculate for each person.
             Object.entries(account.by_person).forEach(([person, hours]) => {

--- a/frontend/src/components/sustainability/BudgetBoard.js
+++ b/frontend/src/components/sustainability/BudgetBoard.js
@@ -4,7 +4,7 @@ import {auth, sustainability} from "../../actions";
 
 import "react-datepicker/dist/react-datepicker.css";
 import BudgetTable from "./BudgetTable";
-import {OTHER_CELL_NAME} from "../../constants";
+import {getAccounts} from "../../selectors/sustainability";
 
 class BudgetBoard extends Component {
     constructor(props) {
@@ -21,103 +21,11 @@ class BudgetBoard extends Component {
         this.loadAccounts();
     }
 
-    calculate_sprint_time(board, data, overall, user_id) {
-        let prefix = overall ? 'overall_' : '';
-        board.issues.forEach(issue => {
-            try {
-                if (issue.current_sprint) {
-                    if (issue.assignee !== OTHER_CELL_NAME && (!user_id || issue.assignee === user_id)) {
-                        data[issue.account][prefix + 'left_this_sprint'] += issue.assignee_time / 3600;
-                    }
-                    if (issue.reviewer_1 !== OTHER_CELL_NAME && (!user_id || issue.reviewer_1 === user_id)) {
-                        data[issue.account][prefix + 'left_this_sprint'] += issue.review_time / 3600;
-                    }
-                } else {
-                    if (issue.assignee !== OTHER_CELL_NAME && (!user_id || issue.assignee === user_id)) {
-                        data[issue.account][prefix + 'planned_next_sprint'] += issue.assignee_time / 3600;
-                    }
-                    if (issue.reviewer_1 !== OTHER_CELL_NAME && (!user_id || issue.reviewer_1 === user_id)) {
-                        data[issue.account][prefix + 'planned_next_sprint'] += issue.review_time / 3600;
-                    }
-                }
-            } catch (e) {
-                // Ignore closed accounts.
-            }
-        })
-    }
-
-    prepareData(accounts, range, id) {
-        if (!accounts || !Object.keys(accounts).length) {
-            return [];
-        }
-        // Operate on copies, so state changes will be handled correctly.
-        accounts = JSON.parse(JSON.stringify(accounts));
-
-        const data = {};
-        let overhead = 0;  // Calculate the overhead of the billable budgets.
-
-        Object.entries(accounts).forEach(([account_type, accounts]) => {
-            accounts.forEach(account => {
-                let entry = account;
-                if (account_type.startsWith('billable')) {
-                    entry.category = 'Billable';
-                    overhead += Math.max(account.overall - account.ytd_goal, 0)
-                } else if (account_type.includes('responsible')) {
-                    entry.category = 'Non-billable cell';
-                } else {
-                    entry.category = 'Non-billable non-cell';
-                }
-                entry.overall_left_this_sprint = 0;
-                entry.overall_planned_next_sprint = 0;
-                entry.left_this_sprint = 0;
-                entry.planned_next_sprint = 0;
-                entry.remaining_next_sprint = 0;
-                data[account.name] = entry;
-            });
-        });
-
-        Object.values(this.props.sprints.boards).forEach(board => this.calculate_sprint_time(board, data, true));
-
-        Object.values(data).forEach(account => {
-            account.remaining_next_sprint = account.next_sprint_goal - account.overall - account.overall_left_this_sprint - account.overall_planned_next_sprint;
-        });
-
-        if (range === 'board' && Object.keys(this.props.sprints.boards).length) {
-            const cell_members = Object.values(this.props.sprints.boards[id].rows).map(x => x.name);
-            Object.values(data).forEach(account => {
-                account.overall = cell_members.reduce((total, member) => total + (account.by_person[member] || 0), 0);
-            });
-
-            this.calculate_sprint_time(this.props.sprints.boards[id], data, false);
-        } else if (range === 'user_board' && Object.keys(this.props.sprints.boards).length) {
-            Object.values(data).forEach(account => account.overall = account.by_person[id] || 0);
-            Object.values(this.props.sprints.boards).forEach(board => this.calculate_sprint_time(board, data, false, id));
-        } else {
-            Object.values(data).forEach(account => {
-                account.left_this_sprint = account.overall_left_this_sprint;
-                account.planned_next_sprint = account.overall_planned_next_sprint;
-            });
-        }
-
-        data['Overhead'] = {
-            name: 'Overhead',
-            overall: overhead,
-            ytd_goal: 0,
-            overall_left_this_sprint: 0,
-            overall_planned_next_sprint: 0,
-            left_this_sprint: 0,
-            planned_next_sprint: 0,
-            remaining_next_sprint: -overhead,
-        };
-
-        return Object.values(data);
-    }
-
     render() {
         const view = JSON.parse(sessionStorage.getItem("view")) || {'name': 'cells'};
         const {name, id} = view;
-        const {budgetsLoading, budgets} = this.props.sustainability;
-        const data = this.prepareData(budgets, name, id);
+        const {budgetsLoading} = this.props.sustainability;
+        const data = this.props.accounts;
 
         return (
             <div className='sustainability'>
@@ -159,6 +67,7 @@ const mapStateToProps = state => {
         auth: state.auth,
         sprints: state.sprints,
         sustainability: state.sustainability,
+        accounts: getAccounts(state),
     }
 };
 

--- a/frontend/src/components/sustainability/BudgetTable.js
+++ b/frontend/src/components/sustainability/BudgetTable.js
@@ -5,9 +5,15 @@ const nameColumn = {width: '35%'};  // 1 cells -> 35 total
 const timeColumn = {width: '9%'};  // 5 cells -> 45% total
 const categoryColumn = {width: '20%'};  // 1 cells -> 20% total
 
-const statusClass = (remaining) => Math.round(remaining) >= 0 ? 'on-track' : 'overtime';
+const statusClass = (remaining, optional=0) => Math.round(remaining - optional) >= 0 ? 'on-track' : 'overtime';
+const monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+const showBudget = (budgets) =>
+    budgets
+        ? budgets.reduce((result, budget, index) =>
+            `${result}\n${monthNames[index]}: ${budget}`, '')
+        : '';
 
-const BudgetTable = ({accounts}) =>
+const BudgetTable = ({accounts, view}) =>
     <div>
         <table className="table sustainability-table">
             <thead>
@@ -37,11 +43,13 @@ const BudgetTable = ({accounts}) =>
             </thead>
             <tbody>
             {accounts.map(item =>
-                <tr key={item.key} className="table-row">
+                <tr key={item.name} className="table-row">
                     <td style={nameColumn}>
-                        {item.name}
+                        <abbr title={showBudget(item.budgets)}>
+                            {item.name}
+                        </abbr>
                     </td>
-                    <td style={timeColumn}>
+                    <td style={timeColumn} className={view === "cells" ? statusClass(item.ytd_goal, item.overall) : ''}>
                         {Math.round(item.overall)}
                     </td>
                     <td style={timeColumn}>

--- a/frontend/src/components/sustainability/SustainabilityBoard.js
+++ b/frontend/src/components/sustainability/SustainabilityBoard.js
@@ -34,10 +34,15 @@ class SustainabilityBoard extends Component {
         const data = {};
 
         if (range === 'board') {
-            const cell_name = this.props.sprints.cells[id];
-            data.billable = accounts.billable_accounts.by_cell[cell_name];
-            data.non_billable = accounts.non_billable_accounts.by_cell[cell_name];
-            data.non_billable_responsible = accounts.non_billable_responsible_accounts.by_cell[cell_name];
+            try {
+                const cell_members = Object.values(this.props.sprints.boards[id].rows).map(x => x.name);
+                data.billable = cell_members.reduce((total, member) => total + (accounts.billable_accounts.by_person[member] || 0), 0);
+                data.non_billable = cell_members.reduce((total, member) => total + (accounts.non_billable_accounts.by_person[member] || 0), 0);
+                data.non_billable_responsible = cell_members.reduce((total, member) => total + (accounts.non_billable_responsible_accounts.by_person[member] || 0), 0);
+            }
+            catch (e) {
+                // Cell's board not loaded.
+            }
         } else if (range === 'user_board') {
             data.billable = accounts.billable_accounts.by_person[id];
             data.non_billable = accounts.non_billable_accounts.by_person[id];
@@ -98,7 +103,8 @@ class SustainabilityBoard extends Component {
                 />
 
                 {
-                    Object.keys(data).length
+                    // Is data present + logical implication for checking whether the cell is loaded.
+                    Object.keys(data).length && (name !== 'board' || this.props.sprints.boards[id])
                         ? <div>
                             {
                                 accountsLoading

--- a/frontend/src/constants/index.js
+++ b/frontend/src/constants/index.js
@@ -24,5 +24,10 @@ export const PARAM_YEAR = 'year=';
 export const PATH_JIRA_BASE = `${process.env.REACT_APP_JIRA_URL}`;
 export const PATH_JIRA_ISSUE = `${PATH_JIRA_BASE}/browse/`;
 
+// Sprints
+export const UNASSIGNED_NAME = "Unassigned";
+export const OTHER_CELL_NAME = "Other Cell";
+export const SPECIAL_USER_NAMES = [UNASSIGNED_NAME, OTHER_CELL_NAME];
+
 // Sustainability
 export const MAX_NON_BILLABLE_TO_BILLABLE_RATIO = parseFloat(process.env.REACT_APP_MAX_NON_BILLABLE_TO_BILLABLE_RATIO);

--- a/frontend/src/selectors/index.js
+++ b/frontend/src/selectors/index.js
@@ -1,0 +1,3 @@
+import * as sustainability from "./sustainability";
+
+export {sustainability}

--- a/frontend/src/selectors/sustainability.js
+++ b/frontend/src/selectors/sustainability.js
@@ -1,0 +1,102 @@
+import {createSelector} from 'reselect'
+import {OTHER_CELL_NAME} from "../constants";
+
+const calculateSprintTime = (board, data, overall, user_id) => {
+    let prefix = overall ? 'overall_' : '';
+    board.issues.forEach(issue => {
+        try {
+            if (issue.current_sprint) {
+                if (issue.assignee !== OTHER_CELL_NAME && (!user_id || issue.assignee === user_id)) {
+                    data[issue.account][prefix + 'left_this_sprint'] += issue.assignee_time / 3600;
+                }
+                if (issue.reviewer_1 !== OTHER_CELL_NAME && (!user_id || issue.reviewer_1 === user_id)) {
+                    data[issue.account][prefix + 'left_this_sprint'] += issue.review_time / 3600;
+                }
+            } else {
+                if (issue.assignee !== OTHER_CELL_NAME && (!user_id || issue.assignee === user_id)) {
+                    data[issue.account][prefix + 'planned_next_sprint'] += issue.assignee_time / 3600;
+                }
+                if (issue.reviewer_1 !== OTHER_CELL_NAME && (!user_id || issue.reviewer_1 === user_id)) {
+                    data[issue.account][prefix + 'planned_next_sprint'] += issue.review_time / 3600;
+                }
+            }
+        } catch (e) {
+            // Ignore closed accounts.
+        }
+    })
+};
+
+const getBudgets = state => state.sustainability.budgets;
+const getBoards = state => state.sprints.boards;
+const getView = state => state.view || JSON.parse(sessionStorage.getItem("view")) || {'name': 'cells'};
+
+export const getAccounts = createSelector(
+    [getBudgets, getView, getBoards],
+    (accounts, view, boards) => {
+        const {name: range, id} = view;
+        if (!accounts || !Object.keys(accounts).length || !boards || (range === 'board' && !boards[id])) {
+            return [];
+        }
+
+        // Operate on copies, so state changes will be handled correctly.
+        accounts = JSON.parse(JSON.stringify(accounts));
+
+        const data = {};
+        let overhead = 0;  // Calculate the overhead of the billable budgets.
+
+        Object.entries(accounts).forEach(([account_type, accounts]) => {
+            accounts.forEach(account => {
+                let entry = account;
+                if (account_type.startsWith('billable')) {
+                    entry.category = 'Billable';
+                    overhead += Math.max(account.overall - account.ytd_goal, 0)
+                } else if (account_type.includes('responsible')) {
+                    entry.category = 'Non-billable cell';
+                } else {
+                    entry.category = 'Non-billable non-cell';
+                }
+                entry.overall_left_this_sprint = 0;
+                entry.overall_planned_next_sprint = 0;
+                entry.left_this_sprint = 0;
+                entry.planned_next_sprint = 0;
+                entry.remaining_next_sprint = 0;
+                data[account.name] = entry;
+            });
+        });
+
+        Object.values(boards).forEach(board => calculateSprintTime(board, data, true));
+
+        Object.values(data).forEach(account => {
+            account.remaining_next_sprint = account.next_sprint_goal - account.overall - account.overall_left_this_sprint - account.overall_planned_next_sprint;
+        });
+
+        if (range === 'board' && Object.keys(boards).length) {
+            const cell_members = Object.values(boards[id].rows).map(x => x.name);
+            Object.values(data).forEach(account => {
+                account.overall = cell_members.reduce((total, member) => total + (account.by_person[member] || 0), 0);
+            });
+
+            calculateSprintTime(boards[id], data, false);
+        } else if (range === 'user_board' && Object.keys(boards).length) {
+            Object.values(data).forEach(account => account.overall = account.by_person[id] || 0);
+            Object.values(boards).forEach(board => calculateSprintTime(board, data, false, id));
+        } else {
+            Object.values(data).forEach(account => {
+                account.left_this_sprint = account.overall_left_this_sprint;
+                account.planned_next_sprint = account.overall_planned_next_sprint;
+            });
+        }
+
+        data['Overhead'] = {
+            name: 'Overhead',
+            overall: overhead,
+            ytd_goal: 0,
+            overall_left_this_sprint: 0,
+            overall_planned_next_sprint: 0,
+            left_this_sprint: 0,
+            planned_next_sprint: 0,
+            remaining_next_sprint: -overhead,
+        };
+
+        return Object.values(data);
+    });

--- a/frontend/src/selectors/sustainability.test.js
+++ b/frontend/src/selectors/sustainability.test.js
@@ -1,0 +1,138 @@
+import {getAccounts} from "./sustainability";
+import {OTHER_CELL_NAME} from "../constants";
+
+test("getAccounts returns empty array if there are no accounts", () => {
+    const state = {
+        sustainability: {
+            budgets: {}
+        },
+        sprints: {
+            board: {}
+        },
+    };
+    expect(getAccounts(state)).toHaveLength(0);
+});
+
+test("getAccounts returns empty array if boards aren't loaded", () => {
+    const state = {
+        sustainability: {
+            budgets: {
+                'billable_accounts': [{
+                    name: 'Billable1',
+                    overall: 3.1415,
+                    ytd_goal: 5,
+                    next_sprint_goal: 10,
+                    budgets: [5, 5, 0, 0, 0, 0, 0, 0, 0, 0],
+                    by_person: {
+                        Member1: 3,
+                        Member2: .1415,
+                    },
+                }]
+            }
+        },
+        sprints: {
+            board: {}
+        },
+    };
+    expect(getAccounts(state)).toHaveLength(0);
+});
+
+const valid_state = {
+    sustainability: {
+        budgets: {
+            'billable_accounts': [{
+                name: 'Billable1',
+                overall: 3.1415,
+                ytd_goal: 5,
+                next_sprint_goal: 10,
+                budgets: [5, 5, 0, 0, 0, 0, 0, 0, 0, 0],
+                by_person: {
+                    Member1: 3,
+                    Member2: .1415,
+                },
+            }]
+        }
+    },
+    sprints: {
+        boards: {
+            1: {
+                'rows': [{
+                    name: 'Member1',
+                }],
+                'issues': [{
+                    key: "Issue1",
+                    account: "Billable1",
+                    assignee: 'Member1',
+                    reviewer_1: OTHER_CELL_NAME,
+                    assignee_time: 10800,
+                    review_time: 509.4,
+                    current_sprint: true,
+                }, {
+                    key: "Issue2",
+                    account: "Billable1",
+                    assignee: 'Member1',
+                    reviewer_1: OTHER_CELL_NAME,
+                    assignee_time: 7200,
+                    review_time: 2585.52,
+                    current_sprint: false,
+                }]
+            },
+            2: {
+                'rows': [{
+                    name: 'Member2',
+                }],
+                'issues': [{
+                    key: "Issue1",
+                    account: "Billable1",
+                    assignee: OTHER_CELL_NAME,
+                    reviewer_1: 'Member2',
+                    assignee_time: 10800,
+                    review_time: 509.4,
+                    current_sprint: true,
+                }, {
+                    key: "Issue2",
+                    account: "Billable1",
+                    assignee: OTHER_CELL_NAME,
+                    reviewer_1: 'Member2',
+                    assignee_time: 7200,
+                    review_time: 2585.52,
+                    current_sprint: false,
+                }]
+            },
+        }
+    },
+};
+
+test("getAccounts properly computes overall data", () => {
+    const result = getAccounts(valid_state);
+    expect(result[0].name).toEqual('Billable1');
+    expect(result[0].left_this_sprint).toEqual(3.1415);
+    expect(result[0].planned_next_sprint).toEqual(2.7182);
+    expect(result[0].remaining_next_sprint).toBeCloseTo(1);
+});
+
+test("getAccounts properly computes cell's data", () => {
+    const state = JSON.parse(JSON.stringify(valid_state));
+    state.view = {
+        name: 'board',
+        id: 1,
+    };
+    const result = getAccounts(state);
+    expect(result[0].name).toEqual('Billable1');
+    expect(result[0].overall).toEqual(3);
+    expect(result[0].left_this_sprint).toEqual(3);
+    expect(result[0].planned_next_sprint).toEqual(2);
+});
+
+test("getAccounts properly computes user's data", () => {
+    const state = JSON.parse(JSON.stringify(valid_state));
+    state.view = {
+        name: 'user_board',
+        id: 'Member2',
+    };
+    const result = getAccounts(state);
+    expect(result[0].name).toEqual('Billable1');
+    expect(result[0].overall).toEqual(0.1415);
+    expect(result[0].left_this_sprint).toEqual(0.1415);
+    expect(result[0].planned_next_sprint).toEqual(0.7182);
+});

--- a/sprints/dashboard/libs/jira.py
+++ b/sprints/dashboard/libs/jira.py
@@ -46,6 +46,15 @@ class Expense(Resource):
             self._parse_raw(raw)
 
 
+class Report(Resource):
+    """Class for representing Tempo Report resource."""
+
+    def __init__(self, options, session, raw=None):
+        Resource.__init__(self, 'report/{0}', options, session)
+        if raw:
+            self._parse_raw(raw)
+
+
 class CustomJira(JIRA):
     """Custom Jira class for using greenhopper and Tempo APIs."""
     GREENHOPPER_BASE_URL = '{server}/rest/greenhopper/1.0/{path}'
@@ -85,6 +94,18 @@ class CustomJira(JIRA):
         )
         expenses = Expense(self._options, self._session, r_json)
         return expenses
+
+    def report(self, from_: str, to: str) -> Report:
+        """
+        Retrieves team worklogs `from_` the date `to` another date (both inclusive).
+        The date format for `from_` and `to` is `%Y-%M-%d`.
+        """
+        r_json = self._get_json(
+            f'report/team/{settings.TEMPO_TEAM_ID}/utilization?dateFrom={from_}&dateTo={to}',
+            base=self.TEMPO_TIMESHEETS_URL,
+        )
+        report = Report(self._options, self._session, r_json)
+        return report
 
 
 @contextmanager

--- a/sprints/dashboard/models.py
+++ b/sprints/dashboard/models.py
@@ -65,7 +65,7 @@ class DashboardIssue:
         self.time_spent = getattr(issue.fields, issue_fields['Time Spent'], 0) or 0
         self.time_estimate = getattr(issue.fields, issue_fields['Remaining Estimate'], 0) or 0
         self.is_epic = getattr(issue.fields, issue_fields['Issue Type']).name == 'Epic'
-        self.account = getattr(issue.fields, issue_fields['Account'])
+        self.account = getattr(issue.fields, issue_fields['Account']).name
 
         try:
             sprint = getattr(issue.fields, issue_fields['Sprint'])

--- a/sprints/dashboard/utils.py
+++ b/sprints/dashboard/utils.py
@@ -249,10 +249,10 @@ def extract_sprint_start_date_from_sprint_name(sprint_name: str) -> str:
 
 def daterange(start: str, end: str) -> Generator[str, None, None]:
     """Generates days from `start_date` to `end_date` (both inclusive)."""
-    start_date = datetime.strptime(start, '%Y-%m-%d')
-    end_date = datetime.strptime(end, '%Y-%m-%d')
+    start_date = datetime.strptime(start, settings.JIRA_API_DATE_FORMAT)
+    end_date = datetime.strptime(end, settings.JIRA_API_DATE_FORMAT)
     for n in range(int((end_date - start_date).days)):
-        yield (start_date + timedelta(n)).strftime('%Y-%m-%d')
+        yield (start_date + timedelta(n)).strftime(settings.JIRA_API_DATE_FORMAT)
 
 
 def get_issue_fields(conn: CustomJira, required_fields: Iterable[str]) -> Dict[str, str]:
@@ -280,7 +280,7 @@ def create_next_sprint(conn: CustomJira, sprints: List[Sprint], cell_key: str, b
     end_date = parse(last_sprint.endDate)
 
     future_next_sprint_number = get_sprint_number(last_sprint) + 1
-    future_name_date = (end_date + timedelta(days=1)).strftime('%Y-%m-%d')
+    future_name_date = (end_date + timedelta(days=1)).strftime(settings.JIRA_API_DATE_FORMAT)
     future_end_date = end_date + timedelta(days=settings.SPRINT_DURATION_DAYS)
     conn.create_sprint(
         name=f'{cell_key}.{future_next_sprint_number} ({future_name_date})',

--- a/sprints/sustainability/migrations/0001_initial.py
+++ b/sprints/sustainability/migrations/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             name='Budget',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(help_text="Account's key.", max_length=255)),
+                ('name', models.CharField(help_text="Account's name.", max_length=255)),
                 ('date', models.DateField(help_text="Year and month of the budget. If not specified, the last month's budget is applied.")),
                 ('hours', models.IntegerField(help_text='Number of available hours for this month.')),
             ],

--- a/sprints/sustainability/serializers.py
+++ b/sprints/sustainability/serializers.py
@@ -4,14 +4,12 @@ from rest_framework import serializers
 # noinspection PyAbstractClass
 class SustainabilityAccountSerializer(serializers.Serializer):
     """Serializer for Accounts."""
-    key = serializers.CharField()
     name = serializers.CharField()
     overall = serializers.FloatField()
-    by_cell = serializers.DictField()
     by_person = serializers.DictField()
     budgets = serializers.ListField(required=False)
     ytd_goal = serializers.FloatField(required=False)
-    next_sprint_budget = serializers.FloatField(required=False)
+    next_sprint_goal = serializers.FloatField(required=False)
 
 
 # noinspection PyAbstractClass

--- a/sprints/sustainability/utils.py
+++ b/sprints/sustainability/utils.py
@@ -1,7 +1,14 @@
+import calendar
+from datetime import datetime
 from typing import (
     Dict,
+    Generator,
     List,
+    Tuple,
 )
+
+from dateutil.parser import parse
+from dateutil.relativedelta import relativedelta
 
 from sprints.dashboard.libs.jira import (
     Account,
@@ -21,3 +28,21 @@ def split_accounts_into_categories(accounts: List[Account]) -> Dict[str, List[Ac
 
         result.setdefault(category, []).append(account)
     return result
+
+
+def generate_month_range(start: str, end: str) -> Generator[Tuple[datetime, datetime], None, None]:
+    """Generates months between `start` and `end` dates."""
+    start_date = parse(start)
+    end_date = parse(end)
+
+    current_date = start_date.replace(day=1)  # First day of each month
+    while current_date < end_date:
+        last_day_of_month = calendar.monthrange(current_date.year, current_date.month)[1]
+        last_date_of_month = current_date.replace(day=last_day_of_month)
+        yield max(current_date, start_date), min(last_date_of_month, end_date)
+        current_date += relativedelta(months=1)
+
+
+def on_error(e: BaseException):
+    """Callback method for retrieving exceptions from async processes."""
+    raise e

--- a/sprints/sustainability/views.py
+++ b/sprints/sustainability/views.py
@@ -1,3 +1,7 @@
+from datetime import datetime
+
+from dateutil.parser import parse
+from django.conf import settings
 from rest_framework import (
     permissions,
     viewsets,
@@ -34,7 +38,10 @@ class SustainabilityDashboardViewSet(viewsets.ViewSet):
 
         with connect_to_jira() as conn:
             if year:
-                dashboard = SustainabilityDashboard(conn, year, None)
+                year_date = parse(year)
+                from_ = year_date.replace(month=1, day=1).strftime(settings.JIRA_API_DATE_FORMAT)
+                to = min(datetime.today(), year_date.replace(month=12, day=31)).strftime(settings.JIRA_API_DATE_FORMAT)
+                dashboard = SustainabilityDashboard(conn, from_, to, budgets=True)
             else:
                 dashboard = SustainabilityDashboard(conn, from_, to)
         serializer = SustainabilityDashboardSerializer(dashboard)


### PR DESCRIPTION
This greatly improves the accounts' retrieval performance and the reliability of the API by moving to the different Tempo API endpoint and making cell-related calculations being performed directly on frontend.

For gathering data from a year the difference for me was 1.5m -> 17s.

## Testing instructions:
1. Set `.env` file (you can take find in a comment on the ticket).
1. Start the backend with `docker-compose -f local.yml up --build`.
1. Create frontend/.env.local and set REACT_APP_GOOGLE_CLIENT_ID there.
1. Load the fixtures (attached to the ticket) with `docker-compose -f local.yml exec django python manage.py loaddata fixtures_sprints.json`.
1. Navigate to frontend and run `npm i && npm start`.
1. Log in.
1. Check the Sustainability and Budget dashboard for overall/cells/yourself and see if the accounts look fine.