### PR TITLE
[BB-1676] Add "clean sprint" rows to the spillover spreadsheet

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -416,6 +416,8 @@ SPRINT_RECURRING_DIRECTIVE = fr"\[~{JIRA_BOT_USERNAME}\]: plan (\d+) hours per s
 SPRINT_REVIEW_DIRECTIVE = fr"\[~{JIRA_BOT_USERNAME}\]: plan (\d+) hours for reviewing this task"
 # Regexp for retrieving spillover reason from the issue's comment.
 SPILLOVER_REASON_DIRECTIVE = fr"\[~{JIRA_BOT_USERNAME}\]: <spillover>(.*)<\/spillover>"
+# Adds ability to ignore users that are not members of the specific cells, but are assigned to their boards.
+SPILLOVER_CLEAN_SPRINT_IGNORED_USERS = set(env.list("SPILLOVER_CLEAN_SPRINT_IGNORED_USERS", default=[]))
 # Regex for extracting sprint data from the name of the sprint.
 # It is also used for distinguishing standard sprints from special ones (e.g. Stretch Goals).
 # The following data is gathered:
@@ -430,7 +432,8 @@ SPRINT_DURATION_DAYS = env.int("SPRINT_DURATION_DAYS", 14)
 # Group 1. cell's key
 # Group 2. issue number
 SPRINT_ISSUE_REGEX = env.str("SPRINT_ISSUE_REGEX", r"(\w+)-(\d+)")
-
+# Exact name of the tickets for logging the clean sprint hints.
+SPRINT_MEETINGS_TICKET = env.str("SPRINT_MEETINGS_TICKET", "Meetings")
 
 # GOOGLE CALENDAR
 # ------------------------------------------------------------------------------
@@ -457,6 +460,11 @@ SPILLOVER_REMINDER_MESSAGE = fr"please fill the spillover reason in the " \
                              fr"[Spillover spreadsheet|{GOOGLE_SPILLOVER_SPREADSHEET_URL}] " \
                              fr"and the next time add the spillover reason as a Jira comment " \
                              fr"matching the following regexp: {{code:python}} {SPILLOVER_REASON_DIRECTIVE}{{code}}"
+# Message to put in the comment as a reminder to the user who forgot to post the spillover avoidance hints.
+SPILLOVER_CLEAN_HINTS_MESSAGE = fr"congratulations for achieving the clean sprint! Please post some hints about " \
+                                fr"managing this on the [Spillover spreadsheet|{GOOGLE_SPILLOVER_SPREADSHEET_URL}] " \
+                                fr"and the next time add them upfront as a Jira comment " \
+                                fr"matching the following regexp: {{code:python}} {SPILLOVER_REASON_DIRECTIVE}{{code}}"
 
 # Specify names of the Tempo account categories.
 TEMPO_BILLABLE_ACCOUNT = env.str("TEMPO_BILLABLE_ACCOUNT", "BILLABLE")

--- a/sprints/dashboard/models.py
+++ b/sprints/dashboard/models.py
@@ -245,8 +245,8 @@ class Dashboard:
                 self.cell_future_sprint = sprint
                 break
 
-        self.future_sprint_start = get_sprint_start_date(self.future_sprints[0])
-        self.future_sprint_end = get_sprint_end_date(self.future_sprints[0], sprints['all'])
+        self.future_sprint_start = get_sprint_start_date(self.cell_future_sprint)
+        self.future_sprint_end = get_sprint_end_date(self.cell_future_sprint, sprints['all'])
 
     def create_mock_users(self):
         """Create mock users for handling unassigned and cross-cell tickets."""

--- a/sprints/dashboard/utils.py
+++ b/sprints/dashboard/utils.py
@@ -418,14 +418,22 @@ def prepare_clean_sprint_rows(
     sprints: Dict[int, Sprint],
 ) -> None:
     """Adds the Google spreadsheet row in the specified format for users who achieved clean sprint."""
-    assignee_index = settings.SPILLOVER_REQUIRED_FIELDS.index("Assignee") + 1  # +1 for the issue's key
+    # +1 for the issue's key
+    status_index = settings.SPILLOVER_REQUIRED_FIELDS.index("Status") + 1
+    sprint_index = settings.SPILLOVER_REQUIRED_FIELDS.index("Sprint") + 1
+    assignee_index = settings.SPILLOVER_REQUIRED_FIELDS.index("Assignee") + 1
+
     members_with_spillovers = {row[assignee_index] for row in rows}
     members_with_clean_sprint = members - members_with_spillovers - settings.SPILLOVER_CLEAN_SPRINT_IGNORED_USERS
-    current_sprint = sprints[extract_sprint_id_from_str(getattr(meetings.fields, issue_fields['Sprint'])[-1])]
+
+    sprint = getattr(meetings.fields, issue_fields['Sprint'])[-1]
+    current_sprint = sprints[extract_sprint_id_from_str(sprint)]
 
     for member in members_with_clean_sprint:
         row = [''] * (len(settings.SPILLOVER_REQUIRED_FIELDS) + 1)
         row[0] = "Clean sprint"
+        row[status_index] = "Done"
+        row[sprint_index] = extract_sprint_name_from_str(sprint)
         row[assignee_index] = member
         row[-1] = get_spillover_reason(meetings, issue_fields, current_sprint, member)
 


### PR DESCRIPTION
This implements adding `Clean sprint` row to spillover spreadsheet. `Comment` field is collected from the specific cell's `Meetings` ticket. This way we can gather hints for achieving clean sprints.

## Testing instructions:
1. Set `.env` file (you can find it in a comment on the ticket).
1. Add `members_with_clean_sprint = ["YOUR FULL NAME"]` under `sprints/dashboard/utils.py:427`.
1. Remove `and not settings.DEBUG` part in `sprints/dashboard/utils.py:442` line.
1. Start the backend with `docker-compose -f local.yml up --build`.
1. Create frontend/.env.local and set REACT_APP_GOOGLE_CLIENT_ID there.
1. Navigate to frontend and run `npm i && npm start`.
1. Go to the cell's board.
1. Use `Complete Sprint` button. Confirm.
1. Check the [dev spreadsheet](https://docs.google.com/spreadsheets/d/1Xlpt0WGanH6v4BgmqgZJ8bgHVEBlmvyb7F-9sRxtInk/edit#gid=1724125923) and see that the `Clean sprint` row have been added.
1. Check that you have been pinged on the `Meetings` ticket.
1. Add spillover directive to the `Meetings` ticket and end the sprint again.
1. Check the [dev spreadsheet](https://docs.google.com/spreadsheets/d/1Xlpt0WGanH6v4BgmqgZJ8bgHVEBlmvyb7F-9sRxtInk/edit#gid=1724125923) and check that your feedback has been collected.