### PR TITLE
[BB-1718] Add missing dependency to prod Dockerfile

### DIFF
--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -4,7 +4,7 @@ ENV PYTHONUNBUFFERED 1
 
 RUN apk update \
   # psycopg2 dependencies
-  && apk add --virtual build-deps gcc python3-dev musl-dev \
+  && apk add --virtual build-deps gcc python3-dev musl-dev git \
   && apk add postgresql-dev \
   # Pillow dependencies
   && apk add jpeg-dev zlib-dev freetype-dev lcms2-dev openjpeg-dev tiff-dev tk-dev tcl-dev \


### PR DESCRIPTION
I forgot to add `git` dependency to prod's Dockerfile. I tested this with `docker-compose -f production.yml build` now.

Merging this as a trivial change.