### PR TITLE
[BB-1625] Replace processes with threads

### DIFF
--- a/sprints/sustainability/models.py
+++ b/sprints/sustainability/models.py
@@ -3,7 +3,7 @@ from datetime import (
     datetime,
     timedelta,
 )
-from multiprocessing.pool import Pool
+from multiprocessing.pool import ThreadPool
 from typing import (
     Dict,
     List,
@@ -163,7 +163,7 @@ class SustainabilityDashboard:
         Fetches aggregated worklogs in an async way.
         FIXME: The exceptions here are logged, but they are not being captured by `p.get()` for some reason.
         """
-        with Pool(processes=settings.MULTIPROCESSING_POOL_SIZE) as pool:
+        with ThreadPool(processes=settings.MULTIPROCESSING_POOL_SIZE) as pool:
             results = [pool.apply_async(
                 self._fetch_accounts_chunk, args, error_callback=on_error)
                 for args in generate_month_range(self.from_, self.to)


### PR DESCRIPTION
This is a hotfix for the single-vCPU deployment.

This is a trivial change, as we're using mostly IO (and not CPU) for `_fetch_accounts_chunk`.