### PR TITLE
[BB-1719] Follow-up fixes

### DIFF
--- a/frontend/src/components/sprint/SprintActionButtons.js
+++ b/frontend/src/components/sprint/SprintActionButtons.js
@@ -13,11 +13,17 @@ class SprintActionButton extends Component {
             return;
         }
 
-        this.btn.setAttribute("disabled", "disabled");
-
-        let complete_url = `${this.props.url}?${PARAM_BOARD_ID}${this.props.board_id}`;
-        callApi(complete_url, "", "POST")
-            .then(response => response.json())
+        let action_url = `${this.props.url}?${PARAM_BOARD_ID}${this.props.board_id}`;
+        callApi(action_url, "", "POST")
+            .then(response => {
+                if (response.status === 200) {
+                    this.btn.setAttribute("disabled", "disabled");
+                    this.btn.removeAttribute("class");
+                    window.alert("The task has been successfully scheduled!\nYou can track its progress with Flower.");
+                } else {
+                    window.alert(`Error ${response.status} returned while scheduling the task.`);
+                }
+            })
     };
 
     render() {

--- a/frontend/src/components/sprint/SprintActionButtons.js
+++ b/frontend/src/components/sprint/SprintActionButtons.js
@@ -23,7 +23,7 @@ class SprintActionButton extends Component {
                 } else {
                     window.alert(`Error ${response.status} returned while scheduling the task.`);
                 }
-            })
+            });
     };
 
     render() {

--- a/sprints/dashboard/tasks.py
+++ b/sprints/dashboard/tasks.py
@@ -125,10 +125,10 @@ def create_role_issues_task(cell: Dict[str, str], sprint_id: int, sprint_number:
 
         for role, users in rotations.items():
             for sprint_part, user in enumerate(users):
-                user_key = conn.search_users(user)[0].key
+                user_name = conn.search_users(user)[0].name
                 fields.update({
-                    jira_fields['Assignee']: {'name': user_key},
-                    jira_fields['Reviewer 1']: {'name': user_key},
+                    jira_fields['Assignee']: {'name': user_name},
+                    jira_fields['Reviewer 1']: {'name': user_name},
                 })
                 for subrole in settings.JIRA_CELL_ROLES.get(role, []):
                     fields.update({


### PR DESCRIPTION
These small changes handle the following cases:
- add confirmation window for sprint actions that use Celery,
- use user names instead of their keys for creating tickets in Jira (apparently these two may differ in some cases),
- handle unassigned issues that spill over during the sprint (this should actually never happen, but it's better to be defensive here.

Merging it as a trivial change.