### PR TITLE
[BB-1816] Cache worklogs and lock "Complete Sprint" button

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,11 @@ orbs:
 jobs:
   test_backend:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
         environment:
           DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
           CELERY_BROKER_URL: redis://redis:6379/0
+          REDIS_URL: redis://redis:6379/0
       - image: circleci/postgres:10.3
         environment:
           POSTGRES_USER: root
@@ -60,7 +61,7 @@ jobs:
 
   build_backend:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
@@ -109,7 +110,7 @@ jobs:
 
   deploy_frontend:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     steps:
       - attach_workspace:
           at: build
@@ -124,7 +125,7 @@ jobs:
 
   deploy_backend:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     steps:
       - run:
           name: Deploy backend

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 ENV PYTHONUNBUFFERED 1
 

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.8-alpine
 
 ENV PYTHONUNBUFFERED 1
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -298,20 +298,12 @@ CELERYD_TASK_TIME_LIMIT = SECONDS_IN_MINUTE * 30
 CELERYD_TASK_SOFT_TIME_LIMIT = CELERYD_TASK_TIME_LIMIT
 
 CELERY_BEAT_SCHEDULE = {
-    "Validate long-term cache every minute.": {
+    "Validate long-term cache integrity every 15 minutes.": {
         "task": "sprints.sustainability.tasks.validate_worklog_cache",
-        "schedule": crontab(),
+        "schedule": crontab(minute='*/15'),
         "kwargs": {
             "long_term": True,
             "force_regenerate": False,
-        },
-    },
-    "Recreate short-term cache every minute.": {
-        "task": "sprints.sustainability.tasks.validate_worklog_cache",
-        "schedule": crontab(),
-        "kwargs": {
-            "long_term": False,
-            "force_regenerate": True,
         },
     },
     "Recreate long-term cache once per week.": {
@@ -570,8 +562,8 @@ TEMPO_START_YEAR = env.int("TEMPO_START_YEAR", 2015)
 CACHE_WORKLOG_MUTABLE_MONTHS = env.int("CACHE_TEMPO_MUTABLE_MONTHS", 2)
 CACHE_WORKLOG_TIMEOUT_LONG_TERM = SECONDS_IN_HOUR * HOURS_IN_DAY * 31
 CACHE_WORKLOG_TIMEOUT_SHORT_TERM = SECONDS_IN_MINUTE * 2
-CACHE_WORKLOG_TIMEOUT_ONE_TIME = SECONDS_IN_MINUTE
-CACHE_SPRINT_TIMEOUT_ONE_TIME = SECONDS_IN_MINUTE
+CACHE_WORKLOG_TIMEOUT_ONE_TIME = SECONDS_IN_MINUTE * 2
+CACHE_SPRINT_TIMEOUT_ONE_TIME = SECONDS_IN_MINUTE * 2
 CACHE_WORKLOG_REGENERATE_LOCK = "cache-worklog-regenerate"
 CACHE_WORKLOG_REGENERATE_LOCK_TIMEOUT_SECONDS = env.int("CACHE_WORKLOG_REGENERATE_LOCK_TIMEOUT_SECONDS", SECONDS_IN_MINUTE * 30)
 CACHE_SPRINT_END_DATE_PREFIX = "sprint_end_date-"

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -5,6 +5,11 @@ import datetime
 import json
 
 import environ
+from celery.schedules import crontab
+
+SECONDS_IN_HOUR = 3600
+SECONDS_IN_MINUTE = 60
+HOURS_IN_DAY = 24
 
 ROOT_DIR = (
     environ.Path(__file__) - 3
@@ -87,6 +92,22 @@ LOCAL_APPS = [
 ]
 # https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
+
+# CACHES
+# ------------------------------------------------------------------------------
+# https://docs.djangoproject.com/en/dev/ref/settings/#caches
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": env("REDIS_URL"),
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            # Mimicing memcache behavior.
+            # http://niwinz.github.io/django-redis/latest/#_memcached_exceptions_behavior
+            "IGNORE_EXCEPTIONS": True,
+        },
+    }
+}
 
 # MIGRATIONS
 # ------------------------------------------------------------------------------
@@ -271,10 +292,41 @@ CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-time-limit
 # TODO: set to whatever value is adequate in your circumstances
-CELERYD_TASK_TIME_LIMIT = 5 * 60
+CELERYD_TASK_TIME_LIMIT = SECONDS_IN_MINUTE * 30
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-soft-time-limit
 # TODO: set to whatever value is adequate in your circumstances
-CELERYD_TASK_SOFT_TIME_LIMIT = 60
+CELERYD_TASK_SOFT_TIME_LIMIT = CELERYD_TASK_TIME_LIMIT
+
+CELERY_BEAT_SCHEDULE = {
+    "Validate long-term cache every minute.": {
+        "task": "sprints.sustainability.tasks.validate_worklog_cache",
+        "schedule": crontab(),
+        "kwargs": {
+            "long_term": True,
+            "force_regenerate": False,
+        },
+    },
+    "Recreate short-term cache every minute.": {
+        "task": "sprints.sustainability.tasks.validate_worklog_cache",
+        "schedule": crontab(),
+        "kwargs": {
+            "long_term": False,
+            "force_regenerate": True,
+        },
+    },
+    "Recreate long-term cache once per week.": {
+        "task": "sprints.sustainability.tasks.validate_worklog_cache",
+        "schedule": crontab(
+            minute=0,
+            hour=0,
+            day_of_week='sun',
+        ),
+        "kwargs": {
+            "long_term": True,
+            "force_regenerate": True,
+        },
+    },
+}
 
 # django-allauth
 # ------------------------------------------------------------------------------
@@ -513,6 +565,21 @@ TEMPO_NON_BILLABLE_ACCOUNT = env.str("TEMPO_NON_BILLABLE_ACCOUNT", "NON-BILLABLE
 TEMPO_NON_BILLABLE_ACCOUNT_NAME = env.str("TEMPO_NON_BILLABLE_ACCOUNT_NAME", "Non-billable account")
 TEMPO_NON_BILLABLE_RESPONSIBLE_ACCOUNT = env.str("TEMPO_NON_BILLABLE_RESPONSIBLE_ACCOUNT", "NON-BILLABLE-CELL")
 TEMPO_NON_BILLABLE_RESPONSIBLE_ACCOUNT_NAME = env.str("TEMPO_NON_BILLABLE_RESPONSIBLE_ACCOUNT_NAME", "Non-billable cell responsibility account")
+TEMPO_START_YEAR = env.int("TEMPO_START_YEAR", 2015)
+
+CACHE_WORKLOG_MUTABLE_MONTHS = env.int("CACHE_TEMPO_MUTABLE_MONTHS", 2)
+CACHE_WORKLOG_TIMEOUT_LONG_TERM = SECONDS_IN_HOUR * HOURS_IN_DAY * 31
+CACHE_WORKLOG_TIMEOUT_SHORT_TERM = SECONDS_IN_MINUTE * 2
+CACHE_WORKLOG_TIMEOUT_ONE_TIME = SECONDS_IN_MINUTE
+CACHE_SPRINT_TIMEOUT_ONE_TIME = SECONDS_IN_MINUTE
+CACHE_WORKLOG_REGENERATE_LOCK = "cache-worklog-regenerate"
+CACHE_WORKLOG_REGENERATE_LOCK_TIMEOUT_SECONDS = env.int("CACHE_WORKLOG_REGENERATE_LOCK_TIMEOUT_SECONDS", SECONDS_IN_MINUTE * 30)
+CACHE_SPRINT_END_DATE_PREFIX = "sprint_end_date-"
+CACHE_SPRINT_END_DATE_TIMEOUT_SECONDS = SECONDS_IN_HOUR * HOURS_IN_DAY * SPRINT_DURATION_DAYS
+CACHE_SPRINT_END_LOCK = "sprint_end_lock-"
+CACHE_SPRINT_END_LOCK_TIMEOUT_SECONDS = SECONDS_IN_HOUR * HOURS_IN_DAY
+CACHE_SUSTAINABILITY_PREFIX = "sustainability-"
+CACHE_SUSTAINABILITY_DATE_FORMAT = "%Y-%m"
 
 # Dict for local account naming.
 TEMPO_ACCOUNT_TRANSLATE = {

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -13,16 +13,6 @@ SECRET_KEY = env(
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1"]
 
-# CACHES
-# ------------------------------------------------------------------------------
-# https://docs.djangoproject.com/en/dev/ref/settings/#caches
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-        "LOCATION": "",
-    }
-}
-
 # TEMPLATES
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#templates

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -23,21 +23,6 @@ DATABASES["default"] = env.db("DATABASE_URL")  # noqa F405
 DATABASES["default"]["ATOMIC_REQUESTS"] = True  # noqa F405
 DATABASES["default"]["CONN_MAX_AGE"] = env.int("CONN_MAX_AGE", default=60)  # noqa F405
 
-# CACHES
-# ------------------------------------------------------------------------------
-CACHES = {
-    "default": {
-        "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": env("REDIS_URL"),
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            # Mimicing memcache behavior.
-            # http://niwinz.github.io/django-redis/latest/#_memcached_exceptions_behavior
-            "IGNORE_EXCEPTIONS": True,
-        },
-    }
-}
-
 # SECURITY
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -27,6 +27,8 @@ CACHES = {
     }
 }
 
+CELERYBEAT_SCHEDULE = {}
+
 # PASSWORDS
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#password-hashers

--- a/frontend/src/actions/sprints.js
+++ b/frontend/src/actions/sprints.js
@@ -1,4 +1,4 @@
-import {PARAM_BOARD_ID, PATH_CELLS, PATH_DASHBOARD} from "../constants";
+import {PATH_DASHBOARD, USE_CACHE} from "../constants";
 import {callApi} from "../middleware/api";
 
 const prepareCellIds = (cells) => {
@@ -12,7 +12,7 @@ export const loadCells = () => {
     return (dispatch) => {
         dispatch({type: "CELLS_LOADING"});
 
-        return callApi(PATH_CELLS)
+        return callApi(PATH_DASHBOARD)
             .then(response => {
                 if (response.status < 500) {
                     return response.json().then(data => {
@@ -36,8 +36,8 @@ export const loadCells = () => {
     }
 };
 
-export const loadBoard = (board_id) => {
-    let board_url = `${PATH_DASHBOARD}?${PARAM_BOARD_ID}${board_id}`;
+export const loadBoard = (board_id, cache = false) => {
+    let board_url = `${PATH_DASHBOARD}${board_id}/` + (cache ? `?${USE_CACHE}` : '');
 
     return (dispatch) => {
         dispatch({type: "BOARD_LOADING", board_id: board_id});
@@ -70,5 +70,5 @@ export const loadBoard = (board_id) => {
                     throw result.data;
                 }
             });
-    }
+    };
 };

--- a/frontend/src/actions/sprints.js
+++ b/frontend/src/actions/sprints.js
@@ -72,3 +72,30 @@ export const loadBoard = (board_id, cache = false) => {
             });
     };
 };
+
+export const checkPermissions = (action, url, board_id) => {
+    let action_url = `${url}${board_id}/`;
+    return (dispatch) => {
+        dispatch({type: "PERMISSION_LOADING", board_id: board_id});
+
+        return callApi(action_url)
+            .then(response => {
+                if (response.status < 500) {
+                    return response.json().then(data => {
+                        return {status: response.status, data};
+                    })
+                } else {
+                    console.log("Server Error!");
+                    throw response;
+                }
+            })
+            .then(result => {
+                if (result.status === 200) {
+                    dispatch({type: 'PERMISSION_GRANTED', board_id: board_id, data: result.data, action: action});
+                    return result.data;
+                } else if (result.status >= 400 && result.status < 500) {
+                    dispatch({type: "PERMISSION_DENIED", data: result.data, action: action});
+                }
+            });
+    };
+};

--- a/frontend/src/components/sprint/Cells.js
+++ b/frontend/src/components/sprint/Cells.js
@@ -20,7 +20,17 @@ const CellsList = ({list}) => {
 class Cells extends Component {
     componentDidMount() {
         sessionStorage.setItem('view', JSON.stringify({'name': 'cells'}));
-        this.props.loadCells();
+        this.loadCells();
+    }
+
+    loadCells() {
+        // Reload dashboards for all cells (using the cache, if possible).
+        this.props.loadCells()
+            .then(result => {
+                if (result && Object.keys(result).length) {
+                    Object.keys(result).forEach(id => this.props.loadBoard(id));
+                }
+            });
     }
 
     render() {
@@ -54,6 +64,9 @@ const mapDispatchToProps = dispatch => {
         },
         loadCells: () => {
             return dispatch(sprints.loadCells());
+        },
+        loadBoard: (board_id) => {
+            return dispatch(sprints.loadBoard(board_id, true));
         }
     }
 };

--- a/frontend/src/components/sprint/SprintActionButtons.js
+++ b/frontend/src/components/sprint/SprintActionButtons.js
@@ -29,35 +29,25 @@ class SprintActionButton extends Component {
             });
     };
 
-    setButton() {
-        if (this.props.sprints.buttons[this.props.action] === true) {
-            this.btn.setAttribute("class", "btn-danger");
-            this.btn.removeAttribute("disabled");
-            this.btn.onclick = this.sprintAction;
-        } else {
-            this.btn.setAttribute("title", this.props.sprints.buttons[this.props.action]);
-        }
-    };
-
     componentDidMount() {
         this.props.checkPermissions(this.props.action, this.props.url, this.props.board_id);
     }
 
     render() {
+        const canUseButton = this.props.sprints.buttons[this.props.action] === true;
+
         if (this.props.is_restricted) {
             if (!this.props.auth.user.is_staff) {
                 return null;
-            }
-            if (this.btn) {
-                this.setButton();
             }
         }
 
         return (
             <button
-                className={this.props.is_restricted ? "" : "btn-warning"}
-                disabled={this.props.is_restricted ? "disabled" : ""}
+                className={this.props.is_restricted ? (canUseButton ? "btn-danger" : "" ) : "btn-warning"}
+                disabled={this.props.is_restricted ? (canUseButton ? "" : "disabled") : ""}
                 onClick={this.sprintAction}
+                title={this.props.sprints.canCloseSprint}
                 ref={btn => {
                     this.btn = btn;
                 }}

--- a/frontend/src/components/sprint/SprintActionButtons.js
+++ b/frontend/src/components/sprint/SprintActionButtons.js
@@ -1,39 +1,64 @@
 import {connect} from "react-redux";
 import React, {Component} from 'react';
-import {PARAM_BOARD_ID, PATH_COMPLETE_SPRINT, PATH_CREATE_NEXT_SPRINT} from "../../constants";
+import {PATH_COMPLETE_SPRINT, PATH_DASHBOARD} from "../../constants";
 import {callApi} from "../../middleware/api";
 import {Link} from "react-router-dom";
 import routes from "../../routes";
 import Button from "../Button";
 
 class SprintActionButton extends Component {
+    checkAction = () => {
+        let action_url = `${this.props.url}${this.props.board_id}/`;
+        callApi(action_url)
+            .then(response => {
+                if (response.status === 200) {
+                    this.btn.setAttribute("class", "btn-danger");
+                    this.btn.removeAttribute("disabled");
+                    this.btn.onclick = this.sprintAction;
+                } else {
+                    return response.json().then(data => {
+                        if (data.detail) {
+                            this.btn.setAttribute("title", data.detail);
+                        }
+                    });
+                }
+            })
+    };
 
     sprintAction = () => {
         if (window.confirm(`Are you sure you want to ${this.props.action}?`) !== true) {
             return;
         }
 
-        let action_url = `${this.props.url}?${PARAM_BOARD_ID}${this.props.board_id}`;
-        callApi(action_url, "", "POST")
+        let action_url = `${this.props.url}${this.props.board_id}/`;
+        callApi(action_url, "", "PUT")
             .then(response => {
                 if (response.status === 200) {
                     this.btn.setAttribute("disabled", "disabled");
                     this.btn.removeAttribute("class");
                     window.alert("The task has been successfully scheduled!\nYou can track its progress with Flower.");
                 } else {
-                    window.alert(`Error ${response.status} returned while scheduling the task.`);
+                    return response.json().then(data => {
+                        let error_message = data.detail ? `\n\n${data.detail}` : "";
+                        window.alert(`Error ${response.status} returned while scheduling the task.${error_message}`);
+                    })
                 }
             });
     };
 
     render() {
-        if (this.props.is_restricted && !this.props.auth.user.is_staff) {
-            return null;
+        if (this.props.is_restricted) {
+            if (!this.props.auth.user.is_staff) {
+                return null;
+            }
+
+            this.checkAction();  // Restricted buttons require validation (obtained by sending `GET` to the same endpoint).
         }
 
         return (
             <button
-                className={this.props.is_restricted ? "btn-danger" : "btn-warning"}
+                className={this.props.is_restricted ? "" : "btn-warning"}
+                disabled={this.props.is_restricted ? "disabled" : ""}
                 onClick={this.sprintAction}
                 ref={btn => {
                     this.btn = btn;
@@ -59,7 +84,7 @@ const SprintActionButtons = ({board_id}) =>
             board_id={board_id}
             caption="Create Next Sprint"
             action="create the next sprint"
-            url={PATH_CREATE_NEXT_SPRINT}
+            url={PATH_DASHBOARD}
             is_restricted={false}
         />
         <SprintActionButtonCombined

--- a/frontend/src/components/sustainability/BudgetBoard.js
+++ b/frontend/src/components/sustainability/BudgetBoard.js
@@ -26,19 +26,28 @@ class BudgetBoard extends Component {
         const {name, id} = view;
         const {budgetsLoading} = this.props.sustainability;
         const data = this.props.accounts;
+        const {boards, boardLoading} = this.props.sprints;
 
         return (
             <div className='sustainability'>
                 <h2>Budget</h2>
                 {
                     // Is data present + logical implication for checking whether the cell is loaded.
-                    Object.keys(data).length && (name !== 'board' || this.props.sprints.boards[id])
+                    Object.keys(data).length && (name !== 'board' || boards[id])
                         ? <div>
                             {
                                 budgetsLoading
                                     ? <div className="loading">
                                         <div className="spinner-border"/>
                                         <p>You are viewing the cached version now. The dashboard is being reloaded…</p>
+                                    </div>
+                                    : <div/>
+                            }
+                            {
+                                boardLoading
+                                    ? <div className="loading">
+                                        <div className="spinner-border"/>
+                                        <p>The <i>Left this sprint</i> and <i>Next Sprint</i> columns are cached versions. The dashboard is being reloaded…</p>
                                     </div>
                                     : <div/>
                             }

--- a/frontend/src/constants/index.js
+++ b/frontend/src/constants/index.js
@@ -10,12 +10,9 @@ export const PATH_LOGOUT = `${PATH_AUTH}/logout/`;
 export const PATH_VERIFY_EMAIL = `${PATH_AUTH}/registration/verify-email/`;
 export const PATH_REFRESH_TOKEN = `${PATH_AUTH}/refresh/`;
 
-export const PATH_SPRINT_DASHBOARD = `${PATH_BASE}/dashboard`;
-export const PATH_CELLS = `${PATH_SPRINT_DASHBOARD}/cells/`;
-export const PATH_DASHBOARD = `${PATH_SPRINT_DASHBOARD}/dashboard/`;
-export const PARAM_BOARD_ID = 'board_id=';
-export const PATH_COMPLETE_SPRINT = `${PATH_SPRINT_DASHBOARD}/complete_sprint/`;
-export const PATH_CREATE_NEXT_SPRINT = `${PATH_SPRINT_DASHBOARD}/create_next_sprint/`;
+export const PATH_DASHBOARD = `${PATH_BASE}/dashboard/`;
+export const PATH_COMPLETE_SPRINT = `${PATH_DASHBOARD}complete_sprint/`;
+export const USE_CACHE = 'cache=true';
 
 export const PATH_SUSTAINABILITY_DASHBOARD = `${PATH_BASE}/sustainability/dashboard/`;
 export const PARAM_FROM = 'from=';

--- a/frontend/src/reducers/sprints.js
+++ b/frontend/src/reducers/sprints.js
@@ -3,6 +3,7 @@ const initialState = {
     boardLoading: true,
     cells: JSON.parse(localStorage.getItem("cells")) || [],
     boards: JSON.parse(localStorage.getItem("boards")) || {},
+    buttons: {}
 };
 
 
@@ -31,6 +32,20 @@ export default function sprints(state=initialState, action) {
             state.boards[action.board_id] = board;
             localStorage.setItem("boards", JSON.stringify(state.boards));
             return {...state, boardLoading: false};
+
+        case 'PERMISSION_GRANTED':
+            const buttons = {};
+            buttons[action.action] = true;
+            return {...state, buttons: buttons};
+
+        case 'PERMISSION_DENIED':
+            const button_err = {};
+            let data = action.data;
+            if (data.detail) {
+                data = data.detail;
+            }
+            button_err[action.action] = data;
+            return {...state, buttons: button_err};
 
         default:
             return state;

--- a/frontend/src/reducers/sprints.js
+++ b/frontend/src/reducers/sprints.js
@@ -39,13 +39,11 @@ export default function sprints(state=initialState, action) {
             return {...state, buttons: buttons};
 
         case 'PERMISSION_DENIED':
-            const button_err = {};
             let data = action.data;
             if (data.detail) {
                 data = data.detail;
             }
-            button_err[action.action] = data;
-            return {...state, buttons: button_err};
+            return {...state, canCloseSprint: data};
 
         default:
             return state;

--- a/local.yml
+++ b/local.yml
@@ -12,6 +12,7 @@ services:
     image: sprints_local_django
     depends_on:
       - postgres
+      - redis
       - celeryworker
     volumes:
       - .:/app
@@ -45,6 +46,9 @@ services:
     depends_on:
       - redis
       - postgres
+      - celerybeat
+    environment:
+      - COLUMNS=80  # https://github.com/celery/celery/issues/5761
 
     ports: []
     command: /start-celeryworker
@@ -58,6 +62,8 @@ services:
 
     ports: []
     command: /start-celerybeat
+    environment:
+      - COLUMNS=80  # https://github.com/celery/celery/issues/5761
 
   flower:
     <<: *django

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -8,7 +8,7 @@ psycopg2==2.8 --no-binary psycopg2  # https://github.com/psycopg/psycopg2
 
 # Testing
 # ------------------------------------------------------------------------------
-mypy==0.701  # https://github.com/python/mypy
+mypy==0.740  # https://github.com/python/mypy
 pytest==4.5.0  # https://github.com/pytest-dev/pytest
 pytest-sugar==0.9.2  # https://github.com/Frozenball/pytest-sugar
 pytest-env~=0.6.2  # https://github.com/MobileDynasty/pytest-env

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ max-line-length = 120
 exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules
 
 [mypy]
-python_version = 3.7
+python_version = 3.8
 check_untyped_defs = True
 ignore_errors = False
 ignore_missing_imports = True

--- a/sprints/dashboard/models.py
+++ b/sprints/dashboard/models.py
@@ -24,8 +24,6 @@ from sprints.dashboard.libs.jira import (
     QuickFilter,
 )
 from sprints.dashboard.utils import (
-    SECONDS_IN_HOUR,
-    SECONDS_IN_MINUTE,
     daterange,
     extract_sprint_id_from_str,
     get_all_sprints,
@@ -35,6 +33,10 @@ from sprints.dashboard.utils import (
     get_sprint_meeting_day_division,
     get_sprint_start_date,
     prepare_jql_query,
+)
+from config.settings.base import (
+    SECONDS_IN_HOUR,
+    SECONDS_IN_MINUTE,
 )
 
 

--- a/sprints/dashboard/urls.py
+++ b/sprints/dashboard/urls.py
@@ -1,16 +1,12 @@
 from rest_framework.routers import DefaultRouter
 
 from sprints.dashboard.views import (
-    CellViewSet,
     CompleteSprintViewSet,
-    CreateNextSprintViewSet,
     DashboardViewSet,
 )
 
 app_name = "dashboard"
 router = DefaultRouter()
-router.register(r'cells', CellViewSet, basename='cells')
-router.register(r'dashboard', DashboardViewSet, basename='dashboard')
-router.register(r'create_next_sprint', CreateNextSprintViewSet, basename='create_next_sprint')
+router.register(r'', DashboardViewSet, basename='dashboard')
 router.register(r'complete_sprint', CompleteSprintViewSet, basename='complete_sprint')
 urlpatterns = router.urls

--- a/sprints/dashboard/utils.py
+++ b/sprints/dashboard/utils.py
@@ -11,7 +11,6 @@ from typing import (
     Iterable,
     List,
     Optional,
-    Set,
     Tuple,
     Union,
 )
@@ -19,6 +18,7 @@ from typing import (
 from dateutil.parser import parse
 from django.conf import settings
 # noinspection PyProtectedMember
+from django.core.cache import cache
 from jira.resources import (
     Board,
     Comment,
@@ -27,14 +27,13 @@ from jira.resources import (
     Sprint,
 )
 
+from config.settings.base import SECONDS_IN_HOUR
 from sprints.dashboard.libs.google import get_availability_spreadsheet
 from sprints.dashboard.libs.jira import (
     CustomJira,
     QuickFilter,
+    connect_to_jira,
 )
-
-SECONDS_IN_HOUR = 3600
-SECONDS_IN_MINUTE = 60
 
 
 class Cell:
@@ -200,6 +199,26 @@ def get_sprint_end_date(sprint: Sprint, sprints: List[Sprint]) -> str:
         date = get_sprint_start_date(future_sprint)
 
     return (parse(date) - timedelta(days=1)).strftime("%Y-%m-%d")
+
+
+def get_current_sprint_end_date(type_='active') -> str:
+    """Retrieves the cached end of sprint date for speeding up more frequent requests."""
+    if not (result := cache.get(f"{settings.CACHE_SPRINT_END_DATE_PREFIX}{type_}")):
+        result = cache.get_or_set(
+            f"{settings.CACHE_SPRINT_END_DATE_PREFIX}{type_}",
+            _get_current_sprint_end_date(type_),
+            settings.CACHE_SPRINT_END_DATE_TIMEOUT_SECONDS
+        )
+    return result
+
+
+def _get_current_sprint_end_date(type_: str) -> str:
+    """Retrieves the end of sprint date. `type_` can be set to `active` or `future`."""
+    with connect_to_jira() as conn:
+        sprints = get_all_sprints(conn)[type_]
+
+    sprint = sprints[0]
+    return get_sprint_end_date(sprint, sprints)
 
 
 def filter_sprints_by_cell(sprints: List[Sprint], key: str) -> List[Sprint]:

--- a/sprints/dashboard/utils.py
+++ b/sprints/dashboard/utils.py
@@ -201,12 +201,12 @@ def get_sprint_end_date(sprint: Sprint, sprints: List[Sprint]) -> str:
     return (parse(date) - timedelta(days=1)).strftime("%Y-%m-%d")
 
 
-def get_current_sprint_end_date(type_='active') -> str:
+def get_current_sprint_end_date(sprint_type='active') -> str:
     """Retrieves the cached end of sprint date for speeding up more frequent requests."""
-    if not (result := cache.get(f"{settings.CACHE_SPRINT_END_DATE_PREFIX}{type_}")):
+    if not (result := cache.get(f"{settings.CACHE_SPRINT_END_DATE_PREFIX}{sprint_type}")):
         result = cache.get_or_set(
-            f"{settings.CACHE_SPRINT_END_DATE_PREFIX}{type_}",
-            _get_current_sprint_end_date(type_),
+            f"{settings.CACHE_SPRINT_END_DATE_PREFIX}{sprint_type}",
+            _get_current_sprint_end_date(sprint_type),
             settings.CACHE_SPRINT_END_DATE_TIMEOUT_SECONDS
         )
     return result

--- a/sprints/dashboard/views.py
+++ b/sprints/dashboard/views.py
@@ -1,11 +1,17 @@
 import http
+from datetime import datetime
+from typing import Optional
 
+from dateutil.parser import parse
+from django.conf import settings
+from django.core.cache import cache
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import (
     permissions,
     viewsets,
 )
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
 from sprints.dashboard.libs.jira import connect_to_jira
@@ -20,70 +26,99 @@ from sprints.dashboard.tasks import (
 )
 from sprints.dashboard.utils import (
     get_cells,
+    get_current_sprint_end_date,
 )
 
-_board_id_param = openapi.Parameter(
-    'board_id', openapi.IN_QUERY, description="cell's board ID", type=openapi.TYPE_INTEGER
+_cache_param = openapi.Parameter(
+    'cache', openapi.IN_QUERY, description="should use cached results?", type=openapi.TYPE_BOOLEAN
 )
 _cell_response = openapi.Response('list of the cells', CellSerializer)
 _dashboard_response = openapi.Response('sprint planning dashboard', DashboardSerializer)
 _task_scheduled_response = openapi.Response("task scheduled")
-
-
-# noinspection PyMethodMayBeStatic
-class CellViewSet(viewsets.ViewSet):
-    """
-    Lists all available cells.
-    """
-    permission_classes = (permissions.IsAuthenticated,)
-
-    @swagger_auto_schema(responses={200: _cell_response})
-    def list(self, _request):
-        with connect_to_jira() as conn:
-            cells = get_cells(conn)
-        serializer = CellSerializer(cells, many=True)
-        return Response(serializer.data)
+_can_complete_sprint = openapi.Response("can complete sprint")
+_cannot_complete_sprint = openapi.Response("cannot complete sprint")
 
 
 # noinspection PyMethodMayBeStatic
 class DashboardViewSet(viewsets.ViewSet):
     """
-    Generates a specified cell's board.
+    Handles listing, retrieving and adding new sprint for cell boards.
     """
     permission_classes = (permissions.IsAuthenticated,)
 
-    @swagger_auto_schema(manual_parameters=[_board_id_param], responses={200: _dashboard_response})
-    def list(self, request):
-        board_id = int(request.query_params.get('board_id'))
+    @swagger_auto_schema(responses={200: _cell_response})
+    def list(self, _request):
+        """Lists all available cells."""
         with connect_to_jira() as conn:
-            dashboard = Dashboard(board_id, conn)
-        serializer = DashboardSerializer(dashboard)
+            cells = get_cells(conn)
+        serializer = CellSerializer(cells, many=True)
         return Response(serializer.data)
 
+    @swagger_auto_schema(manual_parameters=[_cache_param], responses={200: _dashboard_response})
+    def retrieve(self, request, pk=None):
+        """Generates a specified cell's board."""
+        use_cache = bool(request.query_params.get('cache', False))
+        data = cache.get(pk) if use_cache else None
 
-# noinspection PyMethodMayBeStatic
-class CreateNextSprintViewSet(viewsets.ViewSet):
-    """
-    Invokes task for creating the next sprint for the chosen cell.
-    """
-    permission_classes = (permissions.IsAuthenticated,)
+        if not data:
+            with connect_to_jira() as conn:
+                dashboard = Dashboard(int(pk), conn)
+                data = DashboardSerializer(dashboard).data
+                if use_cache:
+                    cache.set(pk, data, settings.CACHE_SPRINT_TIMEOUT_ONE_TIME)
+        return Response(data)
 
-    @swagger_auto_schema(manual_parameters=[_board_id_param], responses={200: _task_scheduled_response})
-    def create(self, request):
-        board_id = int(request.query_params.get('board_id'))
-        create_next_sprint_task.delay(board_id)
+    @swagger_auto_schema(responses={200: _task_scheduled_response})
+    def update(self, _request, pk=None):
+        """Invokes task for creating the next sprint for the chosen cell."""
+        create_next_sprint_task.delay(int(pk))
         return Response(data='', status=http.HTTPStatus.OK)
 
 
 # noinspection PyMethodMayBeStatic
 class CompleteSprintViewSet(viewsets.ViewSet):
     """
-    Invokes task for uploading spillovers and ending the sprint for the chosen cell.
+    Handles ending the sprint for the chosen cell.
     """
     permission_classes = (permissions.IsAdminUser,)
 
-    @swagger_auto_schema(manual_parameters=[_board_id_param], responses={200: _task_scheduled_response})
-    def create(self, request):
-        board_id = int(request.query_params.get('board_id'))
-        complete_sprint_task.delay(board_id)
+    @staticmethod
+    def is_forbidden_to_end_sprint(board_id: int, acquire_lock: bool = False) -> Optional[str]:
+        """
+        Checks if the sprint can be closed now. If it cannot be closed, this returns the reason. There are 2 conditions:
+        1. The current day is the last day of the current sprint.
+        2. The lock for ending the sprint is not acquired.
+
+        Acquire a lock for a day, if `acquire_lock` specified.
+        """
+        end_date = parse(get_current_sprint_end_date())
+        if datetime.now() < end_date:
+            return "The current day is not the last day of the current sprint."
+
+        if (acquire_lock and not cache.add(
+            f'{settings.CACHE_SPRINT_END_LOCK}{board_id}', True, settings.CACHE_SPRINT_END_LOCK_TIMEOUT_SECONDS
+        )) or (not acquire_lock and cache.get(f'{settings.CACHE_SPRINT_END_LOCK}{board_id}', False)):
+            return "The completion task is already running or hasn't been completed successfully."
+
+        return None
+
+    @swagger_auto_schema(responses={200: _can_complete_sprint, 403: _cannot_complete_sprint})
+    def retrieve(self, _request, pk=None):
+        """Checks if the sprint can be closed now. Otherwise returns proper error message."""
+        if error_message := self.is_forbidden_to_end_sprint(pk):
+            raise PermissionDenied(detail=error_message)
+        return Response(data='', status=http.HTTPStatus.OK)
+
+    @swagger_auto_schema(responses={200: _task_scheduled_response, 403: _cannot_complete_sprint})
+    def update(self, _request, pk=None):
+        """
+        Invokes task for uploading spillovers and ending the sprint for the chosen cell.
+
+        Sets a lock in the cache, so it won't be possible to schedule the sprint completion task twice for one cell.
+        We want to set it here (instead of doing it inside the task) to avoid race conditions.
+        """
+        if error_message := self.is_forbidden_to_end_sprint(pk, acquire_lock=True):
+            raise PermissionDenied(detail=error_message)
+
+        complete_sprint_task.delay(int(pk))
         return Response(data='', status=http.HTTPStatus.OK)

--- a/sprints/sustainability/models.py
+++ b/sprints/sustainability/models.py
@@ -118,7 +118,8 @@ class SustainabilityAccount:
         """
         partial_budget = 0.
         for n in range(int((end - start).days)):
-            if (date := start + timedelta(n)).weekday() < 5:  # Do not count weekends.
+            date = (start + timedelta(n))
+            if date.weekday() < 5:  # Do not count weekends.
                 partial_budget += daily_budget[date.month]
 
         return partial_budget
@@ -191,7 +192,8 @@ class SustainabilityDashboard:
         """Wraps fetching account chunks for caching."""
         key = f"{settings.CACHE_SUSTAINABILITY_PREFIX}{from_} - {to}"
         if force:
-            cache.set(key, SustainabilityDashboard._fetch_accounts_chunk(from_, to), cache_timeout)
+            cache.set(key, categories := SustainabilityDashboard._fetch_accounts_chunk(from_, to), cache_timeout)
+            return categories
 
         if not (categories := cache.get(key)):
             categories = cache.get_or_set(key, SustainabilityDashboard._fetch_accounts_chunk(from_, to), cache_timeout)

--- a/sprints/sustainability/models.py
+++ b/sprints/sustainability/models.py
@@ -12,17 +12,12 @@ from typing import (
 
 from dateutil.parser import parse
 from django.conf import settings
+from django.core.cache import cache
 from django.db import models
 from jira.resources import PropertyHolder
 
-from sprints.dashboard.libs.jira import (
-    CustomJira,
-    connect_to_jira,
-)
-from sprints.dashboard.utils import (
-    get_all_sprints,
-    get_sprint_end_date,
-)
+from sprints.dashboard.libs.jira import connect_to_jira
+from sprints.dashboard.utils import get_current_sprint_end_date
 from sprints.sustainability.utils import (
     generate_month_range,
     on_error,
@@ -123,8 +118,7 @@ class SustainabilityAccount:
         """
         partial_budget = 0.
         for n in range(int((end - start).days)):
-            date = (start + timedelta(n))
-            if date.weekday() < 5:  # Do not count weekends.
+            if (date := start + timedelta(n)).weekday() < 5:  # Do not count weekends.
                 partial_budget += daily_budget[date.month]
 
         return partial_budget
@@ -145,8 +139,7 @@ class SustainabilityDashboard:
     Aggregates accounts into a single dashboard.
     """
 
-    def __init__(self, conn: CustomJira, from_: str, to: str, budgets: bool = False) -> None:
-        self.jira_connection = conn
+    def __init__(self, from_: str, to: str, budgets: bool = False) -> None:
         self.generate_budgets = budgets
         self.from_ = from_
         self.to = to
@@ -165,7 +158,10 @@ class SustainabilityDashboard:
         """
         with ThreadPool(processes=settings.MULTIPROCESSING_POOL_SIZE) as pool:
             results = [pool.apply_async(
-                self._fetch_accounts_chunk, args, error_callback=on_error)
+                self.fetch_accounts_chunk,
+                args + (settings.CACHE_WORKLOG_TIMEOUT_ONE_TIME,),
+                error_callback=on_error,
+            )
                 for args in generate_month_range(self.from_, self.to)
             ]
             output = [p.get(settings.MULTIPROCESSING_TIMEOUT) for p in results]
@@ -184,13 +180,22 @@ class SustainabilityDashboard:
             setattr(self, category, getattr(self, category).values())
 
             if self.generate_budgets:
-                sprints = get_all_sprints(self.jira_connection)['future']
-                future_sprint = sprints[0]
-                end_date = get_sprint_end_date(future_sprint, sprints)
+                end_date = get_current_sprint_end_date('future')
 
                 accounts = getattr(self, category)
                 for account in accounts:
                     account.calculate_budgets(parse(self.from_), parse(end_date))
+
+    @staticmethod
+    def fetch_accounts_chunk(from_: str, to: str, cache_timeout=0, force=False) -> Dict[str, Dict]:
+        """Wraps fetching account chunks for caching."""
+        key = f"{settings.CACHE_SUSTAINABILITY_PREFIX}{from_} - {to}"
+        if force:
+            cache.set(key, SustainabilityDashboard._fetch_accounts_chunk(from_, to), cache_timeout)
+
+        if not (categories := cache.get(key)):
+            categories = cache.get_or_set(key, SustainabilityDashboard._fetch_accounts_chunk(from_, to), cache_timeout)
+        return categories
 
     @staticmethod
     def _fetch_accounts_chunk(from_: str, to: str) -> Dict[str, Dict]:

--- a/sprints/sustainability/tasks.py
+++ b/sprints/sustainability/tasks.py
@@ -1,0 +1,56 @@
+import calendar
+from datetime import datetime
+
+from dateutil.parser import parse
+from dateutil.relativedelta import relativedelta
+from django.conf import settings
+from django.core.cache import cache
+
+from config import celery_app
+from .models import SustainabilityDashboard
+from .utils import generate_month_range
+
+
+@celery_app.task()
+def validate_worklog_cache(long_term=True, force_regenerate=False) -> bool:
+    """
+    Validate worklog caches for all months in the specified range and regenerates them, if required.
+    It uses `settings.CACHE_WORKLOG_REGENERATE_LOCK` lock to avoid race conditions during regenerating long term caches.
+
+    :param long_term: if true then checks all worklogs from `settings.TEMPO_START_YEAR` until the end of current month.
+           Otherwise checks only the last `settings.CACHE_WORKLOG_MUTABLE_MONTHS` mutable months.
+    :param force_regenerate: If true, regenerates cache for each month in the specified range.
+    """
+    today = datetime.today()
+    last_day_of_month = calendar.monthrange(today.year, today.month)[1]
+    end_date = today.replace(day=last_day_of_month)
+
+    if long_term:
+        # Validate cache for all one-month periods from the beginning of `settings.TEMPO_START_YEAR` to the present one.
+        if not cache.add(
+            settings.CACHE_WORKLOG_REGENERATE_LOCK, True, settings.CACHE_WORKLOG_REGENERATE_LOCK_TIMEOUT_SECONDS
+        ):  # Cache regeneration is still running or has ended unsuccessfully.
+            return False
+
+        start_year = parse(str(settings.TEMPO_START_YEAR))
+        start_date = start_year.replace(month=1, day=1)
+        cache_timeout = settings.CACHE_WORKLOG_TIMEOUT_LONG_TERM
+    else:
+        # Validate cache only for the last `settings.CACHE_WORKLOG_MUTABLE_MONTHS` mutable months.
+        start_date = (today - relativedelta(months=settings.CACHE_WORKLOG_MUTABLE_MONTHS - 1)).replace(day=1)
+        cache_timeout = settings.CACHE_WORKLOG_TIMEOUT_SHORT_TERM
+
+    start_str = start_date.strftime(settings.JIRA_API_DATE_FORMAT)
+    end_str = end_date.strftime(settings.JIRA_API_DATE_FORMAT)
+
+    for month_start, month_end in generate_month_range(start_str, end_str):
+        SustainabilityDashboard.fetch_accounts_chunk(
+            str(month_start),
+            str(month_end),
+            cache_timeout=cache_timeout,
+            force=force_regenerate,
+        )
+
+    if long_term:
+        cache.delete(settings.CACHE_WORKLOG_REGENERATE_LOCK)
+    return True


### PR DESCRIPTION
This implements caching the worklogs. Its purpose is to be as transparent as possible, so it doesn't alter the underlying logic.
This also includes locking the "Complete Sprint button" (described in the instructions), which needed caching changes to work properly.

I also updated Python to have more concise syntax with [assignment expressions (PEP 572)](https://www.python.org/dev/peps/pep-0572/).

## Testing instructions 
1. Set `.env` file (you can find it in a comment on the ticket).
1. Start the backend with `docker-compose -f local.yml up --build`.
1. Set frontend/.env.local file (you can find it in a comment on the ticket).
1. Navigate to frontend and run `npm i && npm start`.
1. Log in.
1. Open http://localhost:5555/tasks (you can find the credentials in `.env` file) and wait for the tasks to complete. This should take around 5 minutes.
1. Open browser's console and log into the dashboard. You should see that `?year=*` and `?from=*` requests are now taking under 400ms instead of over 30s.
1. Go to the cell's dashboard and press `Complete Sprint` button. Refresh the page and hover over the disabled button to see that the reason is displayed properly there.