### PR TITLE
WIP: [SE-1702] Small fixes

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -36,6 +36,7 @@ services:
       - local_postgres_data_backups:/backups
     env_file:
       - ./.envs/.local/.postgres
+      - ./.env
 
   redis:
     image: redis:5.0


### PR DESCRIPTION
Included:
- *Allow overriding the default postgres variables from .env*. Otherwise, only the settings from `.envs/.local/.postgres` are read, and the database will only be created with the `postgres_user` user instead of the one requested by `POSTGRES_USER` in `.env`
- more to come