### PR TITLE
[BB-2186] Support special vacation

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -539,7 +539,7 @@ GOOGLE_API_CREDENTIALS = {
 # By default we're using f"{name} off" format, which works fine with `name` being at least user's first name.
 # CAUTION: we're not checking for duplicated names, so in case we'll have two people with the same first name,
 #          both of them will need to provide the full name in the calendar.
-GOOGLE_CALENDAR_VACATION_REGEX = env.str("GOOGLE_CALENDAR_VACATION_REGEX", r"(\w+) off")
+GOOGLE_CALENDAR_VACATION_REGEX = env.str("GOOGLE_CALENDAR_VACATION_REGEX", r"^(?P<user>\w+)\s(?P<action>.*?)(?:(?P<hours>\d+)\s?h.*?)?$")
 GOOGLE_SPILLOVER_SPREADSHEET = env.str("GOOGLE_SPILLOVER_SPREADSHEET")
 GOOGLE_CONTACT_SPREADSHEET = env.str("GOOGLE_CONTACT_SPREADSHEET")
 GOOGLE_AVAILABILITY_RANGE = env.str("GOOGLE_AVAILABILITY_RANGE")
@@ -607,4 +607,4 @@ SUSTAINABILITY_MAX_NON_BILLABLE_TO_BILLABLE_CELL_RATIO = env.float("SUSTAINABILI
 
 # Pool size for making parallel API requests
 MULTIPROCESSING_POOL_SIZE = env.int("MULTIPROCESSING_POOL_SIZE", 32)
-MULTIPROCESSING_TIMEOUT = env.int("MULTIPROCESSING_TIMEOUT", 32)
+MULTIPROCESSING_TIMEOUT = env.int("MULTIPROCESSING_TIMEOUT", 128)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -536,9 +536,10 @@ GOOGLE_API_CREDENTIALS = {
   "token_uri": env.str("GOOGLE_API_TOKEN_URI", "https://oauth2.googleapis.com/token"),
 }
 # Regex for retrieving users' vacations from Google Calendar. This one is case-insensitive.
-# By default we're using f"{name} off" format, which works fine with `name` being at least user's first name.
-# CAUTION: we're not checking for duplicated names, so in case we'll have two people with the same first name,
-#          both of them will need to provide the full name in the calendar.
+# It supports two basic cases:
+# - `{name} off`, `{name} away`, etc. for full vacation.
+# - `{name} available 4 hours/day`, `{name} 3h`, etc. for reduced availability.
+# FIXME: It doesn't currently support people with the same name, so, if needed, we'll need to change it.
 GOOGLE_CALENDAR_VACATION_REGEX = env.str("GOOGLE_CALENDAR_VACATION_REGEX", r"^(?P<user>\w+)\s(?P<action>.*?)(?:(?P<hours>\d+)\s?h.*?)?$")
 GOOGLE_SPILLOVER_SPREADSHEET = env.str("GOOGLE_SPILLOVER_SPREADSHEET")
 GOOGLE_CONTACT_SPREADSHEET = env.str("GOOGLE_CONTACT_SPREADSHEET")


### PR DESCRIPTION
## What it is
This adds support for scheduling [special vacation](https://handbook.opencraft.com/en/latest/vacation/#special-vacation) - reduced time off.

## How it works
Due to many mistakes and oversights we relaxed regex to treat any event starting with member's name as the vacation. Additionally, if it's followed with any word and then a number after which comers letter "h", it is treated as reduced time off - **the provided number of hours indicates user's availability per day**. Some working examples:
- Piotr off
- Piotr away
- Piotr reduced 4 h only
- Piotr reduced time off (4h/day)

## Testing instructions 
1. Set `.env` file (you can find it in a comment on the ticket).
1. Start the backend with `docker-compose -f local.yml up --build`.
1. Create superuser with `docker-compose -f local.yml exec django python manage.py createsuperuser`
1. Run migrations with `docker-compose -f local.yml migrate`.
1. Navigate to `frontend` directory and run `npm i && npm start`.
1. Log in.
1. Create some test events and see if they appear on the dashboard in `Vacation` column.