### PR TITLE
[BB-2276] Fix creating role-specific tickets when the future sprint does not exist

### DIFF
--- a/sprints/dashboard/tasks.py
+++ b/sprints/dashboard/tasks.py
@@ -243,6 +243,7 @@ def complete_sprint_task(board_id: int) -> None:
                 future_next_sprint_number = get_sprint_number(future_next_sprint)
             else:
                 future_next_sprint_number = create_next_sprint_task(board_id)
+                future_next_sprint = get_next_sprint(sprints, next_sprint)
 
             cell_dict = {
                 'key': cell.key,


### PR DESCRIPTION
`future_next_sprint` is used by the `create_role_issues_task` below, but if the future sprint does not exist, then its value is `None`. Therefore we need to reassign this variable after creating new sprint.