### PR TITLE
[BB-2908] Fix calculating spreadsheet column names

### DIFF
--- a/sprints/dashboard/tests/test_utils.py
+++ b/sprints/dashboard/tests/test_utils.py
@@ -6,6 +6,7 @@ from django.test import override_settings
 
 from sprints.dashboard.tests.helpers import does_not_raise
 from sprints.dashboard.utils import (
+    _column_number_to_excel,
     _get_sprint_meeting_day_division_for_member,
     extract_sprint_id_from_str,
     extract_sprint_name_from_str,
@@ -285,6 +286,24 @@ def test_prepare_spillover_rows():
     ]
     # noinspection PyTypeChecker
     assert prepare_spillover_rows(test_issues, issue_fields, {}) == expected_result
+
+
+@pytest.mark.parametrize(
+    "test_input, expected", [
+        (1, 'A'),
+        (26, 'Z'),
+        (27, 'AA'),
+        (52, 'AZ'),
+        (53, 'BA'),
+        (702, 'ZZ'),
+        (703, 'AAA'),
+        (18278, 'ZZZ'),
+        (18279, 'AAAA'),
+        (214570915, 'RANDOM'),
+    ],
+)
+def test_column_number_to_excel(test_input, expected):
+    assert _column_number_to_excel(test_input) == expected
 
 
 @pytest.mark.parametrize(

--- a/sprints/dashboard/utils.py
+++ b/sprints/dashboard/utils.py
@@ -532,13 +532,17 @@ def prepare_commitment_spreadsheet(dashboard, spreadsheet: List[List[str]]) -> T
 
 def get_commitment_range(spreadsheet: List[List[str]], cell_name: str) -> str:
     """Retrieve the proper range for the spreadsheet, depending on the cell and number of currently stored sprints."""
-    column_number = base_10_to_n(len(spreadsheet), len(string.ascii_uppercase))
+    column_number = _column_number_to_excel(len(spreadsheet) + 1)
     return f"'{cell_name} Commitments'!{column_number}3"
 
 
-def base_10_to_n(num: int, b: int, numerals: str = string.ascii_uppercase) -> str:
-    """Convert `num` to the desired base `b` with selected `numerals`"""
-    return ((num == 0) and numerals[0]) or (base_10_to_n(num // b, b, numerals).lstrip(numerals[0]) + numerals[num % b])
+def _column_number_to_excel(column: int) -> str:
+    """Convert column number to Excel-style cell name."""
+    result: List[str] = []
+    while column:
+        column, reminder = divmod(column - 1, len(string.ascii_uppercase))
+        result[:0] = string.ascii_uppercase[reminder]
+    return ''.join(result)
 
 
 def _get_sprint_meeting_day_division_for_member(hours: str) -> float:


### PR DESCRIPTION
## What it is
This chages the way we are calculating Excel-like column names for Google Spreadsheets, as the previous implementation was buggy for letters after `Z`. It also adds some tests to ensure this won't happen again.

## Testing instructions 
1. Open [this spreadsheet](https://docs.google.com/spreadsheets/d/1Xlpt0WGanH6v4BgmqgZJ8bgHVEBlmvyb7F-9sRxtInk/edit#gid=1636833065) on the `Bebop Commitments` tab and scroll to the last column on the right.
1. Set `.env` (you can find it in a comment on the ticket).
1. Build the backend with `docker-compose -f local.yml build`.
1. Run migrations with `docker-compose -f local.yml run django python manage.py migrate`.
1. Open Django shell with `docker-compose -f local.yml run django python manage.py shell_plus`.
1. Run the following commands there:
   ```python
   from sprints.dashboard.tasks import upload_commitments_task
   upload_commitments_task(26, 'Bebop')
   ```
1. After the command completes there should be a new column right after the last one on the spreadsheet from the point 1 of this instruction.