### PR TITLE
[Hotfix] Hide users not included in quickfilters

### DIFF
--- a/sprints/dashboard/models.py
+++ b/sprints/dashboard/models.py
@@ -361,6 +361,11 @@ class Dashboard:
 
         self.dashboard.pop(self.other_cell, None)
 
+        # Hide users that are not included in the Sprint board's quickfilters.
+        for user in list(self.dashboard.keys()):
+            if user != self.unassigned_user and user.name not in self.members:
+                self.dashboard.pop(user)
+
         # Calculate commitments for each user.
         for row in self.rows:
             if row.user != self.unassigned_user:


### PR DESCRIPTION
This aligns the board with the logic behind retrieving commitments.

Merging as a hotfix.