### PR TITLE
[BB-3130] Allow hiding spillovers and flagged tickets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,11 @@ For each member of the cell this view displays:
 4. Committed time, which is the sum of all estimation hours.
 5. Goal for the next sprint, which is calculated by summing up user's commitments for each day of the sprint and subtracting `SPRINT_HOURS_RESERVED_FOR_MEETINGS` and `Vacation` hours from it.
 6. Remaining time, which is the result of `Goal` - `Committed`.
+7. Toggles:
+    a) Ongoing work. Default: true.
+        This is useful to for planning the next sprint upfront by making an assumption that all work from the current sprint will be completed on time.
+    b) Accepted (flagged) tickets. Default: false.
+        If tickets are preassigned and flagged, then the assignees can use this option to determine whether they need to pass on some tickets.
 
 User's dashboard
 ~~~~~~~~~~~~~~~~
@@ -64,6 +69,8 @@ This view shows all assigned (as `Assignee` or `Reviewer 1`) tickets of the user
 4. Remaining time for the current user
 5. Sprint indicator (active or future one)
 6. Epic/Story indicator
+
+Note: if a ticket is flagged, then its row's background will be yellow.
 
 Caching
 ~~~~~~~

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -407,6 +407,7 @@ JIRA_REQUIRED_FIELDS = (
     "Reviewer 1",
     "Account",
     "Epic Link",
+    "Flagged",
 )
 # Fields required for documenting spillovers.
 SPILLOVER_REQUIRED_FIELDS = (

--- a/frontend/src/components/Table.css
+++ b/frontend/src/components/Table.css
@@ -79,6 +79,10 @@ tr:hover td {
   font-weight: bold;
 }
 
+.table .flagged > td {
+  background: yellow;
+}
+
 .sustainability-table td {
   width: 25%;
 }

--- a/frontend/src/components/sprint/Table.js
+++ b/frontend/src/components/sprint/Table.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {Component} from 'react';
 import '../Table.css';
 import {Link} from "react-router-dom";
 import {PATH_JIRA_ISSUE} from "../../constants";
@@ -16,130 +16,213 @@ const accumulateTime = (list, property) => {
     return Math.round(accumulatedTime / 3600);
 }
 
-const Table = ({list, url}) =>
-    <table className="table">
-        <thead>
-        <tr className="table-header">
-            <td style={nameColumn}/>
-            <td style={spilloverColumn}>
-                Spillover
-            </td>
-            <td style={newWorkColumn}>
-                New Work
-            </td>
-        </tr>
-        <tr className="table-header">
-            <td style={nameColumn}>
-                User
-            </td>
-            <td style={timeColumn}>
-                My Work
-            </td>
-            <td style={timeColumn}>
-                Reviews
-            </td>
-            <td style={timeColumn}>
-                Upstream
-            </td>
-            <td style={unestimatedColumn}>
-                Unestimated
-            </td>
-            <td style={timeColumn}>
-                My work
-            </td>
-            <td style={timeColumn}>
-                Reviews
-            </td>
-            <td style={timeColumn}>
-                Epic
-            </td>
-            <td style={unestimatedColumn}>
-                Unestimated
-            </td>
-            <td style={timeColumn}>
-                Vacation
-            </td>
-            <td style={timeColumn}>
-                Committed
-            </td>
-            <td style={timeColumn}>
-                Goal
-            </td>
-            <td style={timeColumn}>
-                Remaining
-            </td>
-        </tr>
-        </thead>
-        <tbody>
-        {list.map(item =>
-            <tr key={item.name} className="table-row">
+
+class Table extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            showSpillovers: true,
+            hideFlaggedTickets: false,
+        }
+    }
+
+    // Subtracts spillover time if showing spillovers is disabled.
+    subtractSpilloverTime = (time, spilloverTime) => {
+        return this.state.showSpillovers ? time : time - spilloverTime.reduce((a, b) => a + b, 0);
+    }
+
+    // Subtracts flagged time if hiding flagged tickets is enabled.
+    subtractFlaggedTime = (time, flaggedTime) => {
+        return this.state.hideFlaggedTickets ? time - flaggedTime : time;
+    }
+
+    calculateCommittedTime = (item) => {
+        return Math.round(
+            this.subtractSpilloverTime(
+                this.subtractFlaggedTime(
+                    item.committed_time,
+                    item.flagged_time
+                ),
+                [item.current_remaining_assignee_time, item.current_remaining_review_time]
+            ) / 3600);
+    }
+
+    calculateRemainingTime = (item) => {
+        return Math.round(
+            this.subtractSpilloverTime(
+                this.subtractFlaggedTime(
+                    item.remaining_time,
+                    -item.flagged_time
+                ),
+                [-item.current_remaining_assignee_time, -item.current_remaining_review_time]
+            ) / 3600);
+    }
+
+    render() {
+        const spilloverToggle = (
+            <input
+                name="toggle-spillover-tickets"
+                type="checkbox"
+                checked={this.state.showSpillovers}
+                onChange={() => this.setState({showSpillovers: !this.state.showSpillovers})}
+            />
+        );
+
+        const flaggedTicketsToggle = (
+            <input
+                name="toggle-flagged-tickets"
+                type="checkbox"
+                checked={this.state.hideFlaggedTickets}
+                onChange={() => this.setState({hideFlaggedTickets: !this.state.hideFlaggedTickets})}
+            />
+        );
+
+        const {list, url} = this.props;
+
+        return (<table className="table">
+            <thead>
+            <tr className="table-header">
+                <td style={nameColumn}/>
+                <td style={spilloverColumn}>
+                    Spillover (<abbr title="Show ongoing tickets - spillovers.">show ongoing: {spilloverToggle}</abbr>)
+                </td>
+                <td style={newWorkColumn}>
+                    New Work (<abbr title="Hide flagged tickets.">only accepted: {flaggedTicketsToggle}</abbr>)
+                </td>
+            </tr>
+            <tr className="table-header">
                 <td style={nameColumn}>
-                    <Link to={`${url}/user/${item.name}`}>{item.name}</Link>
+                    User
                 </td>
                 <td style={timeColumn}>
-                    {Math.round(item.current_remaining_assignee_time / 3600)}
+                    My Work
                 </td>
                 <td style={timeColumn}>
-                    {Math.round(item.current_remaining_review_time / 3600)}
+                    Reviews
                 </td>
                 <td style={timeColumn}>
-                    {Math.round(item.current_remaining_upstream_time / 3600)}
+                    Upstream
                 </td>
                 <td style={unestimatedColumn}>
-                    {item.current_unestimated.map(ticket =>
-                        <li key={ticket}>
-                            <a href={PATH_JIRA_ISSUE + ticket.key} title={ticket.summary} target="_blank" rel="noopener noreferrer">{ticket.key}</a>
-                        </li>
+                    Unestimated
+                </td>
+                <td style={timeColumn}>
+                    My work
+                </td>
+                <td style={timeColumn}>
+                    Reviews
+                </td>
+                <td style={timeColumn}>
+                    Epic
+                </td>
+                <td style={unestimatedColumn}>
+                    Unestimated
+                </td>
+                <td style={timeColumn}>
+                    Vacation
+                </td>
+                <td style={timeColumn}>
+                    Committed
+                </td>
+                <td style={timeColumn}>
+                    Goal
+                </td>
+                <td style={timeColumn}>
+                    Remaining
+                </td>
+            </tr>
+            </thead>
+            <tbody>
+            {list.map(item =>
+                <tr key={item.name} className="table-row">
+                    <td style={nameColumn}>
+                        <Link to={`${url}/user/${item.name}`}>{item.name}</Link>
+                    </td>
+                    <td style={timeColumn}>
+                        {this.state.showSpillovers ? Math.round(item.current_remaining_assignee_time / 3600) : 0}
+                    </td>
+                    <td style={timeColumn}>
+                        {this.state.showSpillovers ? Math.round(item.current_remaining_review_time / 3600) : 0}
+                    </td>
+                    <td style={timeColumn}>
+                        {Math.round(item.current_remaining_upstream_time / 3600)}
+                    </td>
+                    <td style={unestimatedColumn}>
+                        {item.current_unestimated.map(ticket =>
+                            <li key={ticket.key}>
+                                <a href={PATH_JIRA_ISSUE + ticket.key} title={ticket.summary} target="_blank" rel="noopener noreferrer">{ticket.key}</a>
+                            </li>
+                        )}
+                    </td>
+                    <td style={timeColumn}>
+                        {Math.round(this.subtractFlaggedTime(item.future_assignee_time, item.flagged_time) / 3600)}
+                    </td>
+                    <td style={timeColumn}>
+                        {Math.round(item.future_review_time / 3600)}
+                    </td>
+                    <td style={timeColumn}>
+                        {Math.round(item.future_epic_management_time / 3600)}
+                    </td>
+                    <td style={unestimatedColumn}>
+                        {item.future_unestimated.map(ticket =>
+                            <li key={ticket.key}>
+                                <a href={PATH_JIRA_ISSUE + ticket.key} title={ticket.summary} target="_blank" rel="noopener noreferrer">{ticket.key}</a>
+                            </li>
+                        )}
+                    </td>
+                    <td style={timeColumn}>
+                        {Math.round(item.vacation_time / 3600)}
+                    </td>
+                    <td style={timeColumn}>
+                        {this.calculateCommittedTime(item)}
+                    </td>
+                    <td style={timeColumn}>
+                        {Math.round(item.goal_time / 3600)}
+                    </td>
+                    <td style={timeColumn} className={statusClass(this.calculateRemainingTime(item))}>
+                        {this.calculateRemainingTime(item)}
+                    </td>
+                </tr>,
+            )}
+            <tr className="table-row">
+                <td style={nameColumn}>
+                    <abbr title="Note that these might not be the accurate sums of the values above, because the calculations are performed on seconds and then they are rounded to hours.">
+                        <b>Total</b>
+                    </abbr>
+                </td>
+                <td style={totalRowPlaceholder}/>
+                <td style={timeColumn}>
+                    {this.subtractSpilloverTime(
+                        this.subtractFlaggedTime(
+                            accumulateTime(list, 'committed_time'),
+                            accumulateTime(list, 'flagged_time')
+                        ),
+                        [
+                            accumulateTime(list, 'current_remaining_assignee_time'),
+                            accumulateTime(list, 'current_remaining_review_time')
+                        ]
                     )}
                 </td>
                 <td style={timeColumn}>
-                    {Math.round(item.future_assignee_time / 3600)}
+                    {accumulateTime(list, 'goal_time')}
                 </td>
                 <td style={timeColumn}>
-                    {Math.round(item.future_review_time / 3600)}
-                </td>
-                <td style={timeColumn}>
-                    {Math.round(item.future_epic_management_time / 3600)}
-                </td>
-                <td style={unestimatedColumn}>
-                    {item.future_unestimated.map(ticket =>
-                        <li key={ticket}>
-                            <a href={PATH_JIRA_ISSUE + ticket.key} title={ticket.summary} target="_blank" rel="noopener noreferrer">{ticket.key}</a>
-                        </li>
+                    {this.subtractSpilloverTime(
+                        this.subtractFlaggedTime(
+                            accumulateTime(list, 'remaining_time'),
+                            accumulateTime(list, 'flagged_time')
+                        ),
+                        [
+                            -accumulateTime(list, 'current_remaining_assignee_time'),
+                            -accumulateTime(list, 'current_remaining_review_time')
+                        ]
                     )}
                 </td>
-                <td style={timeColumn}>
-                    {Math.round(item.vacation_time / 3600)}
-                </td>
-                <td style={timeColumn}>
-                    {Math.round(item.committed_time / 3600)}
-                </td>
-                <td style={timeColumn}>
-                    {Math.round(item.goal_time / 3600)}
-                </td>
-                <td style={timeColumn} className={statusClass(item.remaining_time)}>
-                    {Math.round(item.remaining_time / 3600)}
-                </td>
-            </tr>,
-        )}
-        <tr className="table-row">
-            <td style={nameColumn}>
-                <abbr title="Note that these might not be the accurate sums of the values above, because the calculations are performed on seconds and then they are rounded to hours.">
-                    <b>Total</b>
-                </abbr>
-            </td>
-            <td style={totalRowPlaceholder}/>
-            <td style={timeColumn}>
-                {accumulateTime(list, 'committed_time')}
-            </td>
-            <td style={timeColumn}>
-                {accumulateTime(list, 'goal_time')}
-            </td>
-            <td style={timeColumn}>
-                {accumulateTime(list, 'remaining_time')}
-            </td>
-        </tr>
-        </tbody>
-    </table>;
+            </tr>
+            </tbody>
+        </table>);
+    }
+}
 
 export default Table;

--- a/frontend/src/components/sprint/UserTable.js
+++ b/frontend/src/components/sprint/UserTable.js
@@ -31,7 +31,7 @@ const UserTable = ({list, username}) =>
         </thead>
         <tbody>
         {list.map(item =>
-            <tr key={item.key} className={"table-row"}>
+            <tr key={item.key} className={"table-row" + (item.is_flagged ? ' flagged' : '')}>
                 <td style={timeColumn}>
                     <a href={PATH_JIRA_ISSUE + item.key} title={item.summary} target="_blank"
                        rel="noopener noreferrer">{item.key}</a>

--- a/sprints/dashboard/models.py
+++ b/sprints/dashboard/models.py
@@ -92,6 +92,7 @@ class DashboardIssue:
             self.reviewer_1 = other_cell
 
         self.is_relevant = self._is_relevant_for_current_cell(cell_key, cell_members)
+        self.is_flagged = self._is_flagged(issue, issue_fields)
 
     def get_bot_directive(self, pattern) -> int:
         """
@@ -175,6 +176,11 @@ class DashboardIssue:
         """
         return self.key.startswith(cell_key) or self.reviewer_1.name in cell_members
 
+    @staticmethod
+    def _is_flagged(issue: Issue, issue_fields: Dict[str, str]) -> bool:
+        """Check whether the ticket has been flagged as "Impediment"."""
+        return any(filter(lambda x: x.value == 'Impediment', getattr(issue.fields, issue_fields['Flagged']) or []))
+
 
 class DashboardRow:
     """Represents single dashboard row (user)."""
@@ -188,6 +194,7 @@ class DashboardRow:
         self.future_review_time = 0
         self.future_epic_management_time = 0
         self.goal_time = 0
+        self.flagged_time = 0
         self.current_unestimated: List[DashboardIssue] = []
         self.future_unestimated: List[DashboardIssue] = []
         self.vacation_time = 0.
@@ -358,6 +365,10 @@ class Dashboard:
             else:
                 assignee.future_assignee_time += issue.assignee_time
                 reviewer_1.future_review_time += issue.review_time
+
+                if issue.is_flagged:
+                    assignee.flagged_time += issue.assignee_time
+                    reviewer_1.flagged_time += issue.review_time
 
         self.dashboard.pop(self.other_cell, None)
 

--- a/sprints/dashboard/serializers.py
+++ b/sprints/dashboard/serializers.py
@@ -27,6 +27,7 @@ class DashboardIssueSerializer(serializers.Serializer):
     status = serializers.CharField()
     assignee_time = serializers.SerializerMethodField()
     review_time = serializers.IntegerField()
+    is_flagged = serializers.BooleanField()
 
     # noinspection PyMethodMayBeStatic
     def get_assignee(self, obj: DashboardIssue):
@@ -54,6 +55,7 @@ class DashboardRowSerializer(serializers.Serializer):
     future_epic_management_time = serializers.IntegerField()
     committed_time = serializers.IntegerField()
     goal_time = serializers.IntegerField()
+    flagged_time = serializers.IntegerField()
     current_unestimated = DashboardIssueSerializer(many=True)
     future_unestimated = DashboardIssueSerializer(many=True)
     remaining_time = serializers.IntegerField()


### PR DESCRIPTION
## What it is
This contains the following changes:
1. Adds a toggle for ongoing work (spillovers). This is useful to for planning the next sprint upfront by making an assumption that all work from the current sprint will be completed on time.
1. Adds a toggle for flagged tickets. If tickets are preassigned and flagged, then the assignees can use this option to determine whether they need to pass on some tickets.
1. Nit: fixes `key` attributes of unestimated tickets in `Table.js`.

![image](https://user-images.githubusercontent.com/3189670/97990262-f5949500-1ddf-11eb-8f2a-9adcedb69749.png)
![image](https://user-images.githubusercontent.com/3189670/97990294-0218ed80-1de0-11eb-8758-8a66d35983c7.png)

**Note:** while testing, you can see that the results might sometimes be off by 1 due to rounding.

## Testing instructions 
1. Set `.env` and `frontend/env.local` (you can find them in a comment on the ticket).
1. Comment out [these two lines](https://github.com/open-craft/sprints/blob/agrendalath/bb-3130-hide_flagged_tickets/frontend/src/App.js#L87-L88). They're irrelevant to the scope, but you won't be able to render these dashboards without additional Jira permissions and I didn't test whether it won't break the whole page, as I have many things cached.
1. Start the backend with `docker-compose -f local.yml up --build`.
1. Register new account and get the verification link with `docker-compose -f local.yml logs django`.
1. Run migrations with `docker-compose -f local.yml exec django python manage.py migrate`.
1. Navigate to `frontend` directory and run `npm i && npm start`.
1. Log in and navigate to cell's board.
1. Use the spillover checkbox and check that the numbers make sense with this enabled and disabled.
1. Flag some ticket from the next sprint and check that the toggle for flagged tickets produces correct results.
1. Go to the user's dashboard and see that the flagged ticket has yellow background.