### PR TITLE
[BB-3173] Fix vacations for negative timezones

### DIFF
--- a/sprints/dashboard/models.py
+++ b/sprints/dashboard/models.py
@@ -441,17 +441,21 @@ class Dashboard:
             a. Positive timezone - this day is completely a part of the active sprint, so this time is ignored (0).
             b. Negative timezone - this day can span the active and next sprint, because user can work after the sprint
                ends. The ratio is represented by `1 - division`.
+               If it does not span, then it is treated as a part of the active sprint.
         2. For the first day of the next sprint, there are two subcases:
             a. Positive timezone - this day can span the active and next sprint, because user can work after the sprint
                ends. The ratio is represented by `1 - division`.
+               If it does not span, then it is treated as a part of the next sprint.
             b. Negative timezone - this day is completely a part of the next sprint, so it is counted as vacations.
         3. For the last day of the next sprint, there are two subcases:
             a. Positive timezone - this day is completely a part of the next sprint, so it is counted as vacations.
             b. Negative timezone - this day can span the next and future next sprint, because user can work after
                the sprint ends. The ratio is represented by `division`.
+               If it does not span, then it is treated as a part of the next sprint.
         4. For the first day of the future next sprint, there are two subcases:
             a. Positive timezone - this day can span the next and future next sprint, because user can work after
                the sprint ends. The ratio is represented by `division`.
+               If it does not span, then it is treated as a part of the future next sprint.
             b. Negative timezone - this day is completely a part of the future next sprint, so this time is ignored (0).
 
         `division` - a part of the user's availability before the start of the sprint.
@@ -461,6 +465,11 @@ class Dashboard:
         """
         division, positive_timezone = self.sprint_division[username]
         vacations = commitments - planned_commitments
+        # For negative timezones non-overlapping days are treated the same way as they are for the positive ones.
+        # I.e. if users are working from 9am to 5pm UTC, it will be the same day regardless of whether they are working
+        # within UTC-1 or UTC+1.
+        if not positive_timezone:
+            division = division or 1
 
         if date < self.future_sprint_start:
             return vacations * (1 - division) if not positive_timezone else 0

--- a/sprints/dashboard/tests/test_models.py
+++ b/sprints/dashboard/tests/test_models.py
@@ -108,28 +108,64 @@ def test_get_bot_directive(test_description, test_directive, expected, raises):
 @pytest.mark.parametrize(
     "commitments, date, planned_commitments, username, division, expected",
     [
-        # For positive timezone the day before sprint starts is within the previous sprint, so division is ignored.
+        # 1. Day before the end of the sprint.
+        # ====================================
+        # a. Positive timezone.
+        # ---------------------
+        # It is within the previous sprint, so any division is ignored.
+        (28800, "2020-11-16", 28700, "x", {"x": (0, True)}, 0),
         (28800, "2020-11-16", 28700, "x", {"x": (0.6, True)}, 0),
-        # For negative timezone the day before sprint can span two sprints...
+        # b. Negative timezone.
+        # ---------------------
+        # It can span two sprints.
         (28800, "2020-11-16", 28700, "x", {"x": (0.4, False)}, 60),
-        # ...but it does not need to do so.
-        (28800, "2020-11-16", 28700, "x", {"x": (0, False)}, 100),
-        # For the positive timezone the first day of the sprint may span two sprints.
+        # Otherwise treat is as a part of the current sprint.
+        (28800, "2020-11-16", 28700, "x", {"x": (0, False)}, 0),
+        # 2. First day of the next sprint.
+        # ================================
+        # a. Positive timezone.
+        # ---------------------
+        # It can span two sprints.
         (28800, "2020-11-17", 28700, "x", {"x": (0.6, True)}, 40),
-        # For the negative timezone the first day of the sprint is only in a single sprint.
+        # Otherwise treat is as a part of the current sprint.
+        (28800, "2020-11-17", 28700, "x", {"x": (0, True)}, 100),
+        # b. Negative timezone.
+        # ---------------------
+        # It can be only in the next sprint.
+        (28800, "2020-11-17", 28700, "x", {"x": (0, False)}, 100),
         (28800, "2020-11-17", 28700, "x", {"x": (0.4, False)}, 100),
-        # For the positive timezone the last day of the sprint is only in a single sprint.
+        # 3. Last day of the next sprint.
+        # ===============================
+        # a. Positive timezone.
+        # ---------------------
+        # It can be only in the next sprint.
+        (28800, "2020-11-30", 28700, "x", {"x": (0, True)}, 100),
         (28800, "2020-11-30", 28700, "x", {"x": (0.6, True)}, 100),
-        # For the negative timezone the last day of the sprint can span two sprints.
+        # b. Negative timezone.
+        # ---------------------
+        # It can span two sprints.
         (28800, "2020-11-30", 28700, "x", {"x": (0.4, False)}, 40),
-        # For the positive timezone the day after last day of the sprint can span two sprints...
+        # Otherwise treat is as a part of the next sprint.
+        (28800, "2020-11-30", 28700, "x", {"x": (0, False)}, 100),
+        # 4. Day after the end of the sprint.
+        # ===================================
+        # a. Positive timezone.
+        # ---------------------
+        # It can span two sprints.
         (28800, "2020-12-1", 28700, "x", {"x": (0.6, True)}, 60),
-        # ... but it does not need to do so.
+        # Otherwise treat is as a part of the future next sprint.
         (28800, "2020-12-1", 28700, "x", {"x": (0, True)}, 0),
-        # For the negative timezone the last day of the sprint is only in a single sprint.
+        # b. Negative timezone.
+        # ---------------------
+        # It can be only in the future next sprint.
+        (28800, "2020-12-1", 28700, "x", {"x": (0, False)}, 0),
         (28800, "2020-12-1", 28700, "x", {"x": (0.4, False)}, 0),
-        # Standard cases - vacations scheduled in the middle of the sprint.
+        # 5. Standard cases.
+        # ==================
+        # Vacations scheduled in the middle of the sprint.
+        (28800, "2020-11-20", 28700, "x", {"x": (0, False)}, 100),
         (28800, "2020-11-20", 28700, "x", {"x": (0.4, False)}, 100),
+        (28800, "2020-11-20", 28700, "x", {"x": (0, True)}, 100),
         (28800, "2020-11-20", 28700, "x", {"x": (0.4, True)}, 100),
     ],
 )


### PR DESCRIPTION
This fixes a bug with calculating vacations for negative timezones from #59. That PR did not invert the division for negative timezones, so these cases were not being classified correctly:
1. Negative timezone, non-overlapping day, vacations at the last day of the active sprint. These were counted as a part of the next sprint instead of the active one.
2. Negative timezone, non-overlapping day, vacations at the last day of the next sprint. These were counted as a part of the future next sprint instead of the next one.

## Testing instructions:
1. Check that the tests are passing.