### PR TITLE
[BB-3566] Fix name collisions and Google auth

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -538,10 +538,11 @@ GOOGLE_API_CREDENTIALS = {
 }
 # Regex for retrieving users' vacations from Google Calendar. This one is case-insensitive.
 # It supports two basic cases:
-# - `{name} off`, `{name} away`, etc. for full vacation.
-# - `{name} available 4 hours/day`, `{name} 3h`, etc. for reduced availability.
-# FIXME: It doesn't currently support people with the same name, so, if needed, we'll need to change it.
-GOOGLE_CALENDAR_VACATION_REGEX = env.str("GOOGLE_CALENDAR_VACATION_REGEX", r"^(?P<user>\w+)\s(?P<action>.*?)(?:(?P<hours>\d+)\s?h.*?)?$")
+# - `{name}: off`, `{name}: away`, etc. for full vacation.
+# - `{name}: available 4 hours/day`, `{name}: 3h`, etc. for reduced availability.
+# DEPRECATED: Events without a colon following a name are enabled only for the backwards compatibility.
+#             This default behavior may be altered in the future.
+GOOGLE_CALENDAR_VACATION_REGEX = env.str("GOOGLE_CALENDAR_VACATION_REGEX", r"^(?:(?:(?P<name>.*?):)|(?P<first_name>\w+))\s(?P<action>.*?)(?:(?P<hours>\d+)\s?h.*?)?$")
 GOOGLE_SPILLOVER_SPREADSHEET = env.str("GOOGLE_SPILLOVER_SPREADSHEET")
 GOOGLE_CONTACT_SPREADSHEET = env.str("GOOGLE_CONTACT_SPREADSHEET")
 GOOGLE_AVAILABILITY_RANGE = env.str("GOOGLE_AVAILABILITY_RANGE")

--- a/config/urls.py
+++ b/config/urls.py
@@ -32,6 +32,8 @@ urlpatterns = [
     path("", lambda request: redirect('/swagger')),
     # Django Admin, use {% url 'admin:index' %}
     path(settings.ADMIN_URL, admin.site.urls),
+    # User management
+    path("users/", include("sprints.users.urls", namespace="users")),
     # Dashboard
     path("dashboard/", include("sprints.dashboard.urls", namespace="dashboard")),
     # Sustainability Dashboard

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,7 +27,7 @@ drf-yasg~=1.20.0  # https://github.com/axnsan12/drf-yasg
 
 # REST auth
 # ------------------------------------------------------------------------------
-git+https://github.com/open-craft/django-rest-auth.git@0.10.0  # fork of https://github.com/Tivix/django-rest-auth with simpleJWT support
+git+https://github.com/open-craft/django-rest-auth.git@0.10.1  # fork of https://github.com/Tivix/django-rest-auth with simpleJWT support
 
 
 # Jira API

--- a/sprints/dashboard/libs/google.py
+++ b/sprints/dashboard/libs/google.py
@@ -64,7 +64,7 @@ def get_vacations(from_: str, to: str) -> List[Dict[str, Union[int, str, Dict[st
                         event["end"]["date"] = (parse(event["end"]["date"]) - timedelta(days=1)).strftime(
                             settings.JIRA_API_DATE_FORMAT
                         )
-                        user = search.get('user')
+                        user = search.get('name') or search.get('first_name')
                         event['user'] = user
                         event['seconds'] = int(search.get('hours', 0) or 0) * SECONDS_IN_HOUR
                         vacations.append(event)

--- a/sprints/dashboard/libs/tests/test_google.py
+++ b/sprints/dashboard/libs/tests/test_google.py
@@ -1,0 +1,26 @@
+import re
+
+import pytest
+from django.conf import settings
+
+
+@pytest.mark.parametrize(
+    "calendar_event, expected_name, expected_action, expected_hours",
+    [
+        ('John off', 'John', 'off', None),  # Deprecated format.
+        ('John Doe off', 'John', 'Doe off', None),  # Deprecated format.
+        ('John 3h', 'John', '', '3'),  # Deprecated format.
+        ('John available 3h/day', 'John', 'available ', '3'),  # Deprecated format.
+        ('John: off', 'John', 'off', None),
+        ('John Doe: off', 'John Doe', 'off', None),
+        ('John Doe: 3h', 'John Doe', '', '3'),
+        ('John Doe: available 3h/day', 'John Doe', 'available ', '3'),
+    ],
+)
+def test_vacation_format(calendar_event, expected_name, expected_action, expected_hours):
+    regex = settings.GOOGLE_CALENDAR_VACATION_REGEX
+    search = re.match(regex, calendar_event, re.IGNORECASE).groupdict()
+
+    assert search.get('name') or search.get('first_name') == expected_name
+    assert search.get('action') == expected_action
+    assert search.get('hours') == expected_hours

--- a/sprints/users/urls.py
+++ b/sprints/users/urls.py
@@ -1,0 +1,14 @@
+from django.urls import path
+
+from sprints.users.views import (
+    user_detail_view,
+    user_redirect_view,
+    user_update_view,
+)
+
+app_name = "users"
+urlpatterns = [
+    path("~redirect/", view=user_redirect_view, name="redirect"),
+    path("~update/", view=user_update_view, name="update"),
+    path("<str:username>/", view=user_detail_view, name="detail"),
+]

--- a/sprints/users/views.py
+++ b/sprints/users/views.py
@@ -1,0 +1,42 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.urls import reverse
+from django.views.generic import DetailView, RedirectView, UpdateView
+
+User = get_user_model()
+
+
+class UserDetailView(LoginRequiredMixin, DetailView):
+
+    model = User
+    slug_field = "username"
+    slug_url_kwarg = "username"
+
+
+user_detail_view = UserDetailView.as_view()
+
+
+class UserUpdateView(LoginRequiredMixin, UpdateView):
+
+    model = User
+    fields = ["name"]
+
+    def get_success_url(self):
+        return reverse("users:detail", kwargs={"username": self.request.user.username})
+
+    def get_object(self):
+        return User.objects.get(username=self.request.user.username)
+
+
+user_update_view = UserUpdateView.as_view()
+
+
+class UserRedirectView(LoginRequiredMixin, RedirectView):
+
+    permanent = False
+
+    def get_redirect_url(self):
+        return reverse("users:detail", kwargs={"username": self.request.user.username})
+
+
+user_redirect_view = UserRedirectView.as_view()


### PR DESCRIPTION
This:
1. Fixes Google auth, which broke due to two reasons:
1.1. The ones described in open-craft/django-rest-auth/pull/1.
1.2. Removal of required views as a part of the cleanup in #59.
1. Adds support for full names in vacation calendar events.

## Testing instructions 
1. Set `.env` and `frontend/env.local` (you can find them in a comment in the Vault).
1. Comment out [these two lines](https://github.com/open-craft/sprints/blob/master/frontend/src/App.js#L87-L88). They're irrelevant to the scope and will only slow down the local environment.
1. Start the backend with `docker-compose -f local.yml up --build` (this is important because we're changing dependencies here).
1. Run migrations with `docker-compose -f local.yml exec django python manage.py migrate`.
1. Navigate to `frontend` directory and run `npm i && npm start`.
1. Log in via Google Auth.
1. Go to [Bebop board](http://localhost:3000/board/26) and check that Daniel does not have any vacations.
1. Go to [Serenity board](http://localhost:3000/board/24) and check that Daniel has 10h of vacation.
1. [Optional] Create some temporary vacation events for both Daniels on the Bebop calendar and check that they work as expected. **Remember to delete them later.**