### PR TITLE
[BB-3174] Fix headers in API calls

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -563,7 +563,7 @@ SPRINT_ASYNC_TASKS = {
     # FIXME: The sprint completion is not automated yet, and this should be done only if the sprints all cells are
     #  completed for all cells. Add this to the sprint completion pipeline, once it's automated.
     "sprints.dashboard.tasks.create_estimation_session_task": {
-        "name": "[ASYNC] Close estimation session",
+        "name": "[ASYNC] Create estimation session",
         "start": 1,  # The first day of the sprint.
         "start_delay": datetime.timedelta(hours=8),
         "one_off": True,

--- a/sprints/dashboard/libs/jira.py
+++ b/sprints/dashboard/libs/jira.py
@@ -375,6 +375,7 @@ def connect_to_jira() -> Iterator[CustomJira]:
                 # Ugly hack, but the Agile Poker REST API returns HTTP 403 without this.
                 'Referer': f'{settings.JIRA_SERVER}'
                 f'/download/resources/com.spartez.jira.plugins.jiraplanningpoker/frontend/index.html',
+                'content-type': 'application/json',
             },
         },
     )


### PR DESCRIPTION
After deploying #69, which added the custom `Referer` header, it turned out that the `content-type` is no longer set correctly, resulting in HTTP 415 response from some endpoints. This adds the missing header, which is enough for our use cases - we are not using Jira endpoints with content types different than `application/json`.