### PR TITLE
Fix detecting sprint injections

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -437,6 +437,7 @@ JIRA_TIME_FIELDS = {
 JIRA_AUTOMATION_FIELDS = (
     JIRA_FIELDS_LABELS := "Labels",
     JIRA_FIELDS_PROJECT := "Project",
+    JIRA_FIELDS_CREATED := "Created",
     JIRA_FIELDS_REPORTER
 )
 # Issue fields with numeric values.

--- a/sprints/dashboard/tests/test_automation.py
+++ b/sprints/dashboard/tests/test_automation.py
@@ -279,18 +279,20 @@ def test_unflag_issue(current_flag: list[dict[str, str]], should_invoke: bool):
 
 @patch("sprints.dashboard.automation.get_specific_day_of_sprint", return_value=parse("2020-10-20"))
 @pytest.mark.parametrize(
-    "changed_date, labels, expected",
+    "created_date, changed_date, labels, expected",
     [
-        ("2020-10-19T23:59:59", [], False),
-        ("2020-10-20T00:00:00", [], True),
-        ("2020-10-20T00:00:00", [settings.SPRINT_ASYNC_INJECTION_LABEL], False),
+        ("2020-10-19T23:59:59", "2020-10-19T23:59:59", [], False),
+        ("2020-10-19T23:59:59", "2020-10-20T00:00:00", [], True),
+        ("2020-10-20T00:00:00", "2020-10-19T23:59:59", [], True),  # This should not be possible.
+        ("2020-10-20T00:00:00", "2020-10-20T00:00:00", [settings.SPRINT_ASYNC_INJECTION_LABEL], False),
     ],
 )
-def test_check_issue_injected(_mock: Mock, changed_date: str, labels: list[str], expected: bool):
+def test_check_issue_injected(_mock: Mock, created_date: str, changed_date: str, labels: list[str], expected: bool):
     mock_jira = Mock()
-    mock_jira.issue_fields = {settings.JIRA_FIELDS_LABELS: "labels"}
+    mock_jira.issue_fields = {settings.JIRA_FIELDS_CREATED: "created", settings.JIRA_FIELDS_LABELS: "labels"}
 
     mock_issue = Mock()
+    setattr(mock_issue.fields, mock_jira.issue_fields[settings.JIRA_FIELDS_CREATED], created_date)
     setattr(mock_issue.fields, mock_jira.issue_fields[settings.JIRA_FIELDS_LABELS], labels)
     mock_issue.changelog.histories = [
         Mock(


### PR DESCRIPTION
This fixes the edge case for detecting sprint injections. If the ticket is created with the "Sprint" value, this is not reflected in its changelog. This adds checking the ticket creation date.

# Testing instructions
1. Set `.env` (you can find them [here](https://vault.opencraft.com:8200/ui/vault/secrets/secret/show/core/Sprints%20Development%20Envs)). There were some recent changes.
1. Build the backend with `docker-compose -f local.yml build --pull`.
1. Run migrations with `docker-compose -f local.yml exec django python manage.py migrate`.
1. Open Django shell with `docker-compose -f local.yml run django python manage.py shell_plus` and run (it takes about 1 minute):
    ```python
    from sprints.dashboard.automation import *
    from sprints.dashboard.libs.jira import *
	
    conn = CustomJira(
        server=settings.JIRA_SERVER,
        basic_auth=(settings.JIRA_USERNAME, settings.JIRA_PASSWORD),
        options={
            'agile_rest_path': GreenHopperResource.AGILE_BASE_REST_PATH,
            'headers': {
                'Referer': 'https://tasks.opencraft.com/download/resources/com.spartez.jira.plugins.jiraplanningpoker/frontend/index.html',
            'content-type': 'application/json',
            }
        }
    )
    issues = get_next_sprint_issues(conn, changelog=True)
    injections = [issue for issue in issues if check_issue_injected(conn, issue)]
    print(injections)
    ```
1. Check that the output contains BB-3901 and BB-3902.