### PR TITLE
[Hotfix] Fix grouped changelogs case in sprint injection detection

### DIFF
--- a/sprints/dashboard/automation.py
+++ b/sprints/dashboard/automation.py
@@ -240,8 +240,10 @@ def check_issue_injected(conn: CustomJira, issue: Issue) -> bool:
         if history.created < cutoff_date:
             break
 
-        if history.items[0].field == "Sprint":
-            return True
+        # Some changelogs can be grouped.
+        for history_item in history.items:
+            if history_item.field == "Sprint":
+                return True
 
     return False
 

--- a/sprints/dashboard/tests/test_automation.py
+++ b/sprints/dashboard/tests/test_automation.py
@@ -299,7 +299,8 @@ def test_check_issue_injected(_mock: Mock, created_date: str, changed_date: str,
             created=(parse(changed_date) - timedelta(seconds=1)).strftime("%Y-%m-%dT%H:%M:%S"),
             items=[Mock(field="Sprint")],
         ),
-        Mock(created=changed_date, items=[Mock(field="Sprint")]),
+        # The `Sprint` field does not need to be the first one in the changelog's item.
+        Mock(created=changed_date, items=[Mock(field="timeestimate"), Mock(field="Sprint")]),
         Mock(
             created=(parse(changed_date) + timedelta(seconds=1)).strftime("%Y-%m-%dT%H:%M:%S"),
             items=[Mock(field="timeoriginalestimate"), Mock(field="timeestimate")],


### PR DESCRIPTION
This fixes the edge case when Jira groups changelogs. It looks like there are multiple cases when updates to the tickets are grouped together - e.g. changing the sprint can be mixed with changing the ticket's estimate.

# Testing instructions
1. Set `.env` (you can find them [here](https://vault.opencraft.com:8200/ui/vault/secrets/secret/show/core/Sprints%20Development%20Envs)). There were some recent changes.
1. Build the backend with `docker-compose -f local.yml build --pull`.
1. Run migrations with `docker-compose -f local.yml exec django python manage.py migrate`.
1. Open Django shell with `docker-compose -f local.yml run django python manage.py shell_plus` and run (it takes about 1 minute):
    ```python
    from sprints.dashboard.automation import *
    from sprints.dashboard.libs.jira import *
	
    conn = CustomJira(
        server=settings.JIRA_SERVER,
        basic_auth=(settings.JIRA_USERNAME, settings.JIRA_PASSWORD),
        options={
            'agile_rest_path': GreenHopperResource.AGILE_BASE_REST_PATH,
            'headers': {
                'Referer': 'https://tasks.opencraft.com/download/resources/com.spartez.jira.plugins.jiraplanningpoker/frontend/index.html',
            'content-type': 'application/json',
            }
        }
    )
    issues = get_next_sprint_issues(conn, True)
    i_dict = {i.key: i for i in issues}
    iss = i_dict.get('BB-3685')
    assert check_issue_injected(conn, iss)
    ```
1. Check that it does not raise an exception.