### PR TITLE
[Hotfix] Fix assigning users to poker sessions, add task filtering

### DIFF
--- a/sprints/dashboard/automation.py
+++ b/sprints/dashboard/automation.py
@@ -85,7 +85,8 @@ def get_unestimated_next_sprint_issues(conn: CustomJira) -> list[Issue]:
         jql_str=f'Sprint IN ({sprints_str}) '
         f'AND "{settings.JIRA_FIELDS_STATUS}" != "{settings.SPRINT_STATUS_ARCHIVED}" '  # Ignore archived.
         f'AND "{settings.JIRA_FIELDS_STORY_POINTS}" is EMPTY '  # Only unestimated.
-        f'AND issuetype NOT IN subTaskIssueTypes()',  # Ignore subtasks.
+        f'AND issuetype NOT IN subTaskIssueTypes()'  # Ignore subtasks.
+        f'AND status = {settings.SPRINT_STATUS_BACKLOG}',  # Include only unstarted issues.
         fields=['None'],  # We don't need any fields here. The `key` attribute will be sufficient.
         maxResults=0,
     )

--- a/sprints/dashboard/tasks.py
+++ b/sprints/dashboard/tasks.py
@@ -521,15 +521,21 @@ def update_estimation_session_task() -> None:
                 # User's `name` and `key` are not always the same.
                 members = get_cell_member_names(conn, get_cell_members(conn.quickfilters(cell.board_id)))
                 member_keys = set(user.key for user in all_users if user.displayName in members)
+
                 current_member_keys = set(user.userKey for user in poker_session.participants)
+                current_scrum_master_keys = set(user.userKey for user in poker_session.scrumMasters)
+
                 all_member_keys = list(current_member_keys | member_keys)
+                all_scrum_master_keys = list(current_scrum_master_keys | member_keys)
 
                 if not settings.DEBUG:  # We don't want to trigger this in the dev environment.
+                    # TODO: Handle 403 response when the bot is not added as a participant.
+                    #  Investigate 500 response from Jira.
                     poker_session.update(
                         {
                             'issuesIds': all_issue_ids,
                             'participants': all_member_keys,
-                            'scrumMasters': all_member_keys,
+                            'scrumMasters': all_scrum_master_keys,
                         },
                         notify=True,
                     )

--- a/sprints/dashboard/tests/test_automation.py
+++ b/sprints/dashboard/tests/test_automation.py
@@ -92,6 +92,7 @@ def test_get_next_sprint_issues(get_all_sprints: Mock, get_issue_fields: Mock, c
     )
 
 
+@override_settings(SPRINT_STATUS_BACKLOG="backlog")
 @patch("sprints.dashboard.automation.get_all_sprints")
 @pytest.mark.parametrize(
     "sprints_all, raises",
@@ -121,7 +122,8 @@ def test_get_unestimated_next_sprint_issues(get_all_sprints: Mock, sprints_all: 
             jql_str=f'Sprint IN (123,124,125) '
             f'AND "{settings.JIRA_FIELDS_STATUS}" != "{settings.SPRINT_STATUS_ARCHIVED}" '
             f'AND "{settings.JIRA_FIELDS_STORY_POINTS}" is EMPTY '
-            f'AND issuetype NOT IN subTaskIssueTypes()',
+            f'AND issuetype NOT IN subTaskIssueTypes()'
+            f'AND status = backlog',
             fields=['None'],
             maxResults=0,
         )


### PR DESCRIPTION
This fixes a case of having a different list of participants and scrum masters - e.g. for the bot account, which should not be a participant of an estimation session.

It also adds task filtering for the estimation session.