### PR TITLE
[Hotfix] Fix updating Jira poker sessions

### DIFF
--- a/sprints/dashboard/libs/jira.py
+++ b/sprints/dashboard/libs/jira.py
@@ -73,7 +73,17 @@ class Poker(Resource):
         # Specify the API for the poker session.
         self._session.headers['content-type'] = 'application/json'
         options = self._options.copy()
-        options.update({'rest_path': 'pokerng', 'rest_api_version': '1.0', 'path': f'session/id/{self.sessionId}'})
+        options.update(
+            {
+                'rest_path': 'pokerng',
+                'rest_api_version': '1.0',
+                # HACK: The `?withUserKeys=true` querystring is used only with `PUT` requests, but the Jira library does
+                #  not allow adding custom data to the URL, so we're using this with all types of requests.
+                #  It could be possible to avoid using this, but this API is undocumented and it would require some
+                #  guessing how users should be passed within a request.
+                'path': f'session/id/{self.sessionId}?withUserKeys=true',
+            }
+        )
         # This attribute is used by the superclass for querying the API.
         self.self = self._base_url.format(**options)
 

--- a/sprints/dashboard/tasks.py
+++ b/sprints/dashboard/tasks.py
@@ -530,7 +530,6 @@ def update_estimation_session_task() -> None:
 
                 if not settings.DEBUG:  # We don't want to trigger this in the dev environment.
                     # TODO: Handle 403 response when the bot is not added as a participant.
-                    #  Investigate 500 response from Jira.
                     poker_session.update(
                         {
                             'issuesIds': all_issue_ids,


### PR DESCRIPTION
This fixes the HTTP 500 response from Jira while updating the session for some cells. It's related to undefined handling of user names vs user keys by Jira.