### PR TITLE
[Hotfix] Do not send emails on the estimation session update

### DIFF
--- a/sprints/dashboard/tasks.py
+++ b/sprints/dashboard/tasks.py
@@ -536,7 +536,7 @@ def update_estimation_session_task() -> None:
                             'participants': all_member_keys,
                             'scrumMasters': all_scrum_master_keys,
                         },
-                        notify=True,
+                        notify=False,  # TODO: This should notify participants only in case of any changes.
                     )
 
 


### PR DESCRIPTION
It has been sending an email in every task run.