### PR TITLE
[BB-4548] Unify sprint start/end dates

### DIFF
--- a/sprints/dashboard/tasks.py
+++ b/sprints/dashboard/tasks.py
@@ -281,13 +281,11 @@ def complete_sprint_task(board_id: int) -> None:
             conn.add_issues_to_sprint(next_sprint.id, issue_keys)
 
             # Open the next sprint.
-            start_date = datetime.now()
-            end_date = datetime.now() + timedelta(days=settings.SPRINT_DURATION_DAYS)
             conn.update_sprint(
                 next_sprint.id,
                 name=next_sprint.name,
-                startDate=start_date.isoformat(),
-                endDate=end_date.isoformat(),
+                startDate=next_sprint.startDate,
+                endDate=next_sprint.endDate,
                 state='active',
             )
 

--- a/sprints/dashboard/utils.py
+++ b/sprints/dashboard/utils.py
@@ -503,10 +503,9 @@ def create_next_sprint(conn: CustomJira, sprints: List[Sprint], cell_key: str, b
     end_date_str = _get_sprint_end_date(start_date_str)
 
     sprint_number = get_sprint_number(last_sprint) + 1
-    name_date = start_date.strftime(settings.JIRA_API_DATE_FORMAT)
 
     return conn.create_sprint(
-        name=f'{cell_key}.{sprint_number} ({name_date})',
+        name=f'{cell_key}.{sprint_number} ({start_date_str})',
         board_id=board_id,
         startDate=start_date_str,
         endDate=end_date_str,

--- a/sprints/dashboard/utils.py
+++ b/sprints/dashboard/utils.py
@@ -309,7 +309,7 @@ def _get_next_sprint(sprints: List[Sprint], previous_sprint_number: int, many=Fa
 
 def get_sprint_start_date(sprint: Sprint) -> str:
     """Returns start date of the sprint."""
-    return extract_sprint_start_date_from_sprint_name(sprint.name)
+    return _extract_sprint_start_date_from_sprint_name(sprint.name)
 
 
 def get_sprint_end_date(sprint: Sprint) -> str:
@@ -439,7 +439,7 @@ def extract_sprint_name_from_str(sprint_str: str) -> str:
     raise AttributeError(f"Invalid `sprint_str`, {pattern} not found.")
 
 
-def extract_sprint_start_date_from_sprint_name(sprint_name: str) -> str:
+def _extract_sprint_start_date_from_sprint_name(sprint_name: str) -> str:
     """Extract sprint start date from sprint's name."""
     search = re.search(settings.SPRINT_REGEX, sprint_name)
     if search:
@@ -497,23 +497,26 @@ def create_next_sprint(conn: CustomJira, sprints: List[Sprint], cell_key: str, b
     """Creates next sprint for the desired cell."""
     sprints = filter_sprints_by_cell(sprints, cell_key)
     last_sprint = sprints[-1]
-    end_date = parse(last_sprint.endDate)
 
-    future_next_sprint_number = get_sprint_number(last_sprint) + 1
-    future_name_date = (end_date + timedelta(days=1)).strftime(settings.JIRA_API_DATE_FORMAT)
-    future_end_date = end_date + timedelta(days=settings.SPRINT_DURATION_DAYS)
+    start_date = parse(get_sprint_end_date(last_sprint)) + timedelta(days=1)
+    start_date_str = start_date.strftime(settings.JIRA_API_DATE_FORMAT)
+    end_date_str = _get_sprint_end_date(start_date_str)
+
+    sprint_number = get_sprint_number(last_sprint) + 1
+    name_date = start_date.strftime(settings.JIRA_API_DATE_FORMAT)
+
     return conn.create_sprint(
-        name=f'{cell_key}.{future_next_sprint_number} ({future_name_date})',
+        name=f'{cell_key}.{sprint_number} ({name_date})',
         board_id=board_id,
-        startDate=end_date.isoformat(),
-        endDate=future_end_date.isoformat(),
+        startDate=start_date_str,
+        endDate=end_date_str,
     )
 
 
 def get_spillover_reason(issue: Issue, issue_fields: Dict[str, str], sprint: Sprint, assignee: str) -> str:
     """Retrieve the spillover reason from the comment matching the `settings.SPILLOVER_REASON_DIRECTIVE` regexp."""
     # For issues spilling over more than once we need to ensure that the comment has been added in the current sprint.
-    sprint_start_date = parse(sprint.startDate)
+    sprint_start_date = parse(get_sprint_start_date(sprint))
 
     # Check each comment created after starting the current sprint.
     comments = getattr(issue.fields, issue_fields['Comment']).comments


### PR DESCRIPTION
This unifies sprint start/end dates by using the higher-level API instead of the native Jira one. The also allows separating the Sprints logic from the Jira-specific features. It's the first step towards creating an abstraction, which is going to be used by [plugins](https://gitlab.com/opencraft/dev/sprints/-/blob/master/docs/discoveries/2.%20Sprints%20v2%20UX.md#12-plugins).

It also adds some tests.

Fixes https://gitlab.com/opencraft/dev/sprints/-/issues/16 (the content of this issue is a little different, so I've added a comment to explain the approach in `complete_sprint_task`).

This is going to be tricky to test manually, as it would require sprint manager permissions + manual API calls, as our Jira version has a very limited way of editing sprint details. Therefore, we can rely on the tests here.

## Testing instructions
1. Check if new tests make sense.
2. Check if the CI passes.

