### PR TITLE
[SE-4489] Adding current and next sprint firefighter context to the checklist

### DIFF
--- a/sprints/dashboard/tasks.py
+++ b/sprints/dashboard/tasks.py
@@ -179,6 +179,12 @@ def trigger_new_sprint_webhooks_task(cell_name: str, sprint_name: str, sprint_nu
     with connect_to_jira() as conn:
         # Dictionary containing rotations: {'FF': ['John Doe',...],...}
         rotations = get_rotations_users(str(sprint_number), cell_name)
+        
+        # get the rotation role for the future sprint that is current sprint number + 1
+        next_sprint_rotations = get_rotations_users(str(sprint_number + 1), cell_name)
+        future_rotations = {f"FS{role}": assignees for role, assignees in next_sprint_rotations.items()}
+        
+        rotations.update(future_rotations)
 
         # A list of jira usernames for a board: ['johndoe1', 'jane_doe_22', ...]
         members = []

--- a/sprints/dashboard/tests/test_utils.py
+++ b/sprints/dashboard/tests/test_utils.py
@@ -370,6 +370,12 @@ def test_get_rotations_roles_for_member():
     assert len(output) == 1
     assert output[0] == 'FF-2'
 
+    # When the member is on Future Sprint Firefighter(FSFF) duty
+    output = get_rotations_roles_for_member('Jake Doe', {'FF': ['Jake Doe', 'John Doe'], 'DD': ['Jane Doe', 'James Doe'], 'FSFF': ['John Doe', 'Jake Doe']})
+    assert len(output) == 2
+    assert output[0] == 'FF-1'
+    assert output[1] == 'FSFF-2'
+
     # When member has no duty
     output = get_rotations_roles_for_member('John Doe', {'FF': ['Jake Doe', 'James Doe'], 'DD': ['Jane Doe', 'James Doe']})
     assert len(output) == 0
@@ -389,8 +395,10 @@ def test_compile_participants_roles():
     ]
 
     rotations_data_dummy = {
-        'ff': ['John Doe', 'Jack'],
-        'dd': ['Jack Doe', 'Jake Doe'],
+        'FF': ['John Doe', 'Jack'],
+        'DD': ['Jack Doe', 'Jake Doe'],
+        'FSFF': ['Jack', 'John Doe'],
+        'FSDD': ['Jake Doe', 'Jack Doe'],
     }
 
     roles_data_dummy = {
@@ -405,9 +413,9 @@ def test_compile_participants_roles():
 
     expected_output = {
         'janedoe@opencraft.com': [],
-        'jackdoe@opencraft.com': ['Sprint Planning Manager', 'DevOps Specialist', 'ff-2', 'dd-1'],
-        'johndoe@opencraft.com': ['Sprint Manager', 'ff-1'],
-        'jakedoe@opencraft.com': ['Recruitment Manager', 'dd-2']
+        'jackdoe@opencraft.com': ['Sprint Planning Manager', 'DevOps Specialist', 'FF-2', 'DD-1', 'FSFF-1', 'FSDD-2'],
+        'johndoe@opencraft.com': ['Sprint Manager', 'FF-1', 'FSFF-2'],
+        'jakedoe@opencraft.com': ['Recruitment Manager', 'DD-2', 'FSDD-1']
     }
 
     TestCase().assertDictEqual(output, expected_output)

--- a/sprints/dashboard/utils.py
+++ b/sprints/dashboard/utils.py
@@ -192,7 +192,7 @@ def get_rotations_roles_for_member(member_name: str, rotations: Dict[str, List[s
     roles = []
 
     for duty, assignees in rotations.items():
-        # Enumeration is used for determining the order of roles in a sprint - e.g. `FF-1`, `DD-2`, etc.
+        # Enumeration is used for determining the order of roles in a sprint - e.g. `FF-1`, `DD-1`, `FSFF-1`, `FSDD-1`, etc.
         for idx, assignee in enumerate(assignees):
             if member_name.startswith(assignee):
                 roles.append(f"{duty}-{idx + 1}")


### PR DESCRIPTION
**Description**
---
This PR changes the current FF-1, FF-2, DD-1, DD-2 role to Current Sprint FF,  Current Sprint DD, Future Sprint FF, and  Future Sprint DD so we can easily define the checklist of the responsibility of these rotational roles.

**Supporting information**
---
JIRA Ticket: [SE-4489](https://tasks.opencraft.com/browse/SE-4489)

**Testing instructions**
---
We have two projects to set up for the testing of this feature.

Sprints Project

-  Clone this repo locally
-  Change the value of these configurations as per staging env
```
JIRA_SERVER=
JIRA_USERNAME=  
JIRA_PASSWORD=
JIRA_CELL_ROLE_ACCOUNT=
JIRA_CELL_ROLES={"FF": [{"name": "Firefighter", "hours": 15, "story_points": 4}, {"name": "Community Relations", "hours": 1, "story_points": 0.5, "account": 33}], "DD": [{"name": "Discovery Duty", "hours": 5, "story_points": 1}]}

GOOGLE_API_PRIVATE_KEY=
GOOGLE_API_CLIENT_EMAIL=
GOOGLE_SPILLOVER_SPREADSHEET=
GOOGLE_CONTACT_SPREADSHEET=
GOOGLE_AVAILABILITY_RANGE=
GOOGLE_ROTATIONS_SPREADSHEET=
GOOGLE_ROTATIONS_RANGE=

HANDBOOK_ROLES_PAGE=https://handbook.opencraft.com/en/latest/cells/
```
-  Run `docker-compose -f local.yml run --rm django python manage.py migrate`
- Run  `docker-compose -f local.yml run --rm django python manage.py createsuperuser` to create a superuser

Crafty Boat Project

-  Clone the [crafty-bot](https://gitlab.com/opencraft/dev/crafty-bot) repo
-  In the .envs/.local directory create a .secret and add `MONDAY_API_TOKEN=<TOKEN>`
-  Change the port for the Django server and flower in the [file](https://gitlab.com/opencraft/dev/crafty-bot/-/blob/master/docker-compose.yml) as port 8000 and 5555 already used by the sprint app
- Change the `MONDAY_SPRINT_CHECKLIST_TEMPLATE_ID`  value to `1353681144`  at this [path](https://gitlab.com/opencraft/dev/crafty-bot/-/blob/master/.envs/.local/.django#L21)

Testing Steps
- Now start the shell for the Sprint app ```docker-compose -f local.yml run --rm django python manage.py shell```
- run below code
```python
from sprints.dashboard.libs.jira import connect_to_jira
from sprints.dashboard.libs.google import (
    get_rotations_users,
    get_future_rotations_users,
)
from sprints.dashboard.utils import (
    get_cell_member_roles,
    get_cell_members,
    compile_participants_roles,
)
from pprint import pprint

sprint_number = 246
cell_name = "Serenity"
board_id = 24
sprint_name = "SE246"
with connect_to_jira() as conn:
    # Dictionary containing rotations: {'FF': ['John Doe',...],...}
    rotations = get_rotations_users(str(sprint_number), cell_name)

    # get the rotation role for the future sprint that is current sprint number + 1
    future_rotations = get_future_rotations_users(str(sprint_number + 1), cell_name)
    rotations = {**rotations, **future_rotations}

    # A list of jira usernames for a board: ['johndoe1', 'jane_doe_22', ...]
    members = []
    usernames = get_cell_members(conn.quickfilters(board_id))
    for username in usernames:
        members.append(conn.user(username))

    # Dictionary containing member roles: {'John Doe': ['Sprint Planning Manager', ...],...}
    cell_member_roles = get_cell_member_roles()

    payload = {
        "board_id": board_id,
        "cell": cell_name,
        "sprint_number": sprint_number,
        "sprint_name": sprint_name,
        "participants": compile_participants_roles(
            members, rotations, cell_member_roles
        ),
        "event_name": "new sprint",
    }

    pprint(payload)

```
- Copy the payload values and change these values. make sure *cell, board_id* are the same as mention below. It will also be good to update participants dict , so other members of the cell don't get an unwanted notification.
```
"board_id": 1,
"cell": "TestCell",
"sprint_number": 13,
"sprint_name": "Sprint - TestCell-13",
```
- Now create a superuser by running this command in the crafty boat  `docker-compose run --rm django python manage.py createsuperuser`
- Now go to crafty boat admin panel  `http://0.0.0.0:<port_you_changed>/admin`
- Create the roles as shown in image below by going to `http://0.0.0.0:<port>/admin/sprint_checklist/role/`
![image](https://user-images.githubusercontent.com/15611967/121434024-58fc2c00-c99a-11eb-9255-fedbdcee55dd.png)

-  Generate the token by going to `http://0.0.0.0:<port>/admin/authtoken/tokenproxy/`, we need the token in curl command
- Run this curl command
```shell
curl --location --request POST 'http://localhost:<port>/api/v1/checklist' \
--header 'Authorization: Token <token generated above>' \
--header 'Content-Type: application/json' \
--data-raw '{
"board_id":1,
"cell":"TestCell",
"sprint_number":13,
"sprint_name":"Sprint - TestCell-13",
"participants": <payload-value-you-get-from-the-sprint-code-you-run-above>
"event_name":"new sprint"
}'
```
- Now check the tasks, should be created for the Future Sprint FF and DD.

**Author Note**
- Please feel free to ping me while testing, if you face any issues.

**Reviewers**
-  [  ] @gabor-boros 

